### PR TITLE
Fix the erroneous "JavaFx user agent needs a desktop environment" on Mac OS X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
     <dependency>
       <groupId>com.microsoft.alm</groupId>
       <artifactId>oauth2-useragent</artifactId>
-      <version>0.5.3</version>
+      <version>0.5.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary

Version 0.5.4 of the oauth2-useragent library contains the fix to the Mac OS X desktop detection when X11 isn't installed.
## Manual testing
1. On a Mac OS X machine:
   1. Run the JAR in `install` mode: success.
   2. `unset DISPLAY`
   3. Run the JAR in `install` mode: success.
2. On a Fedora machine:
   1. Run the JAR in `install` mode: success.
   2. `unset DISPLAY`
   3. Run the JAR in `install` mode: failure (as expected).

Mission accomplished!
