### PR TITLE
Making the RPM an artifact in the pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
                 <id>generate-rpm</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>rpm</goal>
+                  <goal>attached-rpm</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
# Manual Testing
* Built project as the release profile and saw RPM was considered an artifact in the output (i.e. the sha is generated for it, etc.)