### PR TITLE
Adding release step to move generated docs to the top level to replac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,17 @@ Licensed under the MIT license. See License.txt in the project root. -->
             </configuration>
           </plugin>
         </plugins>
+        <resources>
+          <resource>
+            <directory>${project.build.directory}</directory>
+            <targetPath>${project.basedir}</targetPath>
+            <filtering>true</filtering>
+            <includes>
+              <include>Install.md</include>
+              <include>ReadMe.md</include>
+            </includes>
+          </resource>
+        </resources>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
…e last release's docs

# Manual Test
* Ran a build not as the release profile and the Install and Read Me stayed the same
* Ran a build as the release profile with a new version number and it was updated in the Install file (Read Me only contains the artifactId as a property which when changed breaks the build).