### PR TITLE
Collect release-worthy artifacts in a folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,25 @@ Licensed under the MIT license. See License.txt in the project root. -->
               </postremoveScriptlet>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <attach>false</attach>
+              <descriptors>
+                <descriptor>src/assembly/artifacts.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </plugin>
         </plugins>
         <resources>
           <resource>

--- a/src/assembly/artifacts.xml
+++ b/src/assembly/artifacts.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (c) Microsoft. All rights reserved.
+  ~ Licensed under the MIT license. See License.txt in the project root.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>artifacts</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <baseDirectory>artifacts</baseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>${project.artifactId}-${project.version}.jar</include>
+        <include>${project.artifactId}-${project.version}.jar.asc</include>
+        <include>*.md</include>
+        <include>git-credential-manager</include>
+        <include>git-credential-manager.rb</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/rpm/${project.artifactId}/RPMS/noarch</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>*.rpm</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
This automates the collection of files that should be archived, published, etc. for a release.  I can now configure my Jenkins job to pull what it needs out of the new folder.

# Manual testing
1. On a Fedora machine, ran:

    ```
    mvn clean verify -P release
    ```
2. The Maven output contained the following near the end:

    ```
    [INFO] --- maven-assembly-plugin:2.6:single (default) @ git-credential-manager ---
    [INFO] Reading assembly descriptor: src/assembly/artifacts.xml
    [INFO] Copying files to /home/oli/oss/gcm4ml/target/git-credential-manager-1.2.1-SNAPSHOT-artifacts
    ```
3.  I then listed the contents of the `target/git-credential-manager-1.2.1-SNAPSHOT-artifacts/` folder:

    ```
    target/git-credential-manager-1.2.1-SNAPSHOT-artifacts/:
    total 348
    -rw-rw-r--. 1 oli oli   2258 Nov 19 23:48 Contributing.md
    -rw-rw-r--. 1 oli oli     93 Nov 19 23:48 git-credential-manager
    -rw-rw-r--. 1 oli oli 152224 Nov 19 23:48 git-credential-manager-1.2.1-SNAPSHOT20151120044835.noarch.rpm
    -rw-rw-r--. 1 oli oli 163250 Nov 19 23:48 git-credential-manager-1.2.1-SNAPSHOT.jar
    -rw-rw-r--. 1 oli oli    473 Nov 19 23:48 git-credential-manager-1.2.1-SNAPSHOT.jar.asc
    -rw-rw-r--. 1 oli oli    733 Nov 19 23:48 git-credential-manager.rb
    -rw-rw-r--. 1 oli oli   5905 Nov 19 23:48 Install.md
    -rw-rw-r--. 1 oli oli   1735 Nov 19 23:48 ReadMe.md
    -rw-rw-r--. 1 oli oli   4981 Nov 19 23:48 ReleaseNotes.md
    ```

Mission accomplished!