### PR TITLE
Fix RPM PGP key filename

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -36,11 +36,11 @@ If you can't use any of the package managers, you can also download [git-credent
 ### Installing on Linux using RPM (recommended)
 
 1. Download [git-credential-manager-1.2.0-1.noarch.rpm](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-1.2.0/git-credential-manager-1.2.0-1.noarch.rpm) and copy the file somewhere locally.
-2. Download the [PGP key used to sign the RPM](https://java.visualstudio.com/Content/RPM-GPG-KEY-olivida.asc).
+2. Download the [PGP key used to sign the RPM](https://java.visualstudio.com/Content/RPM-GPG-KEY-olivida.txt).
 3. Import the signing key into RPM's database:
 
     ```
-    sudo rpm --import RPM-GPG-KEY-olivida.asc
+    sudo rpm --import RPM-GPG-KEY-olivida.txt
     ```
 4. Verify the GCM RPM:
 

--- a/templates/Install.md
+++ b/templates/Install.md
@@ -36,11 +36,11 @@ If you can't use any of the package managers, you can also download [${project.a
 ### Installing on Linux using RPM (recommended)
 
 1. Download [${project.artifactId}-${project.version}-1.noarch.rpm](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/${project.artifactId}-${project.version}/${project.artifactId}-${project.version}-1.noarch.rpm) and copy the file somewhere locally.
-2. Download the [PGP key used to sign the RPM](https://java.visualstudio.com/Content/RPM-GPG-KEY-olivida.asc).
+2. Download the [PGP key used to sign the RPM](https://java.visualstudio.com/Content/RPM-GPG-KEY-olivida.txt).
 3. Import the signing key into RPM's database:
 
     ```
-    sudo rpm --import RPM-GPG-KEY-olivida.asc
+    sudo rpm --import RPM-GPG-KEY-olivida.txt
     ```
 4. Verify the GCM RPM:
 


### PR DESCRIPTION
# Manual testing
On my Fedora 22 machine:
1. Downloaded the `RPM-GPG-KEY-olivida.txt` file.
2. Imported it:

    ```
    sudo rpm --import ~/Downloads/RPM-GPG-KEY-olivida.txt
    ```
3. Verified the key was imported:

    ```
    rpm -qa gpg-pubkey* --qf '%{name} %{version} %{release} %{summary}\n'
    ```
...which produced the following output:

    ```
    gpg-pubkey ba34dbc2 5605a22c gpg(Oli Dagenais (Microsoft) <olivida@microsoft.com>)
    gpg-pubkey 8e1431d5 53bcbac7 gpg(Fedora (22) <fedora@fedoraproject.org>)
    ```
...and our key ID (**ba34dbc2**) is indeed there.
4. Ran a *release* build to force construction of the RPM:

    ```
    mvn clean verify -P release -Dgpg.keyname='Oli Dagenais (Microsoft) <olivida@microsoft.com>'
    ```
5. Verified the signature of the generated RPM:

    ```
    rpm --checksig --verbose target/git-credential-manager-1.2.1-SNAPSHOT-artifacts/git-credential-manager-1.2.1-SNAPSHOT20151120183028.noarch.rpm
    ```
...which yielded the following:

    ```
    target/git-credential-manager-1.2.1-SNAPSHOT-artifacts/git-credential-manager-1.2.1-SNAPSHOT20151120183028.noarch.rpm:
        Header V4 RSA/SHA256 Signature, key ID ba34dbc2: OK
        Header SHA1 digest: OK (82080191961bcf53512cbe9088105f303e37798e)
        V4 RSA/SHA256 Signature, key ID ba34dbc2: OK
        MD5 digest: OK (154f4e399b71419417dfc1b216a0bf08)
    ```

Mission accomplished!