### PR TITLE
Adding .deb package creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
 
   <build>
     <extensions>
+      <!-- Needed for custom deb packaging https://github.com/tcurdt/jdeb/blob/master/docs/maven.md -->
       <extension>
         <groupId>org.vafer</groupId>
         <artifactId>jdeb</artifactId>
@@ -100,7 +101,6 @@ Licensed under the MIT license. See License.txt in the project root. -->
           <include>Install.md</include>
           <include>ReadMe.md</include>
           <include>git-credential-manager.rb</include>
-          <include>control</include>
         </includes>
       </resource>
       <resource>
@@ -450,7 +450,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
                   <goal>jdeb</goal>
                 </goals>
                 <configuration>
-                  <controlDir>${project.build.directory}</controlDir>
+                  <controlDir>${project.basedir}/templates</controlDir>
                   <dataSet>
                     <data>
                       <src>${project.build.directory}/git-credential-manager-${project.version}.jar</src>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@ Licensed under the MIT license. See License.txt in the project root. -->
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>1.4</version>
+      </extension>
+    </extensions>
     <resources>
       <resource>
         <directory>${basedir}</directory>
@@ -86,20 +93,14 @@ Licensed under the MIT license. See License.txt in the project root. -->
         </includes>
       </resource>
       <resource>
-        <directory>${project.basedir}/templates</directory>
+        <directory>${basedir}/templates</directory>
         <targetPath>${project.build.directory}</targetPath>
         <filtering>true</filtering>
         <includes>
           <include>Install.md</include>
           <include>ReadMe.md</include>
-        </includes>
-      </resource>
-      <resource>
-        <directory>${basedir}/templates</directory>
-        <targetPath>${project.build.directory}</targetPath>
-        <filtering>true</filtering>
-        <includes>
           <include>git-credential-manager.rb</include>
+          <include>control</include>
         </includes>
       </resource>
       <resource>
@@ -437,6 +438,42 @@ Licensed under the MIT license. See License.txt in the project root. -->
                 <descriptor>src/assembly/artifacts.xml</descriptor>
               </descriptors>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.vafer</groupId>
+            <artifactId>jdeb</artifactId>
+            <version>1.4</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>jdeb</goal>
+                </goals>
+                <configuration>
+                  <controlDir>${project.build.directory}</controlDir>
+                  <dataSet>
+                    <data>
+                      <src>${project.build.directory}/git-credential-manager-${project.version}.jar</src>
+                      <type>file</type>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/usr/lib</prefix>
+                        <filemode>755</filemode>
+                      </mapper>
+                    </data>
+                    <data>
+                      <src>${project.build.directory}/git-credential-manager</src>
+                      <type>file</type>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/usr/bin</prefix>
+                        <filemode>755</filemode>
+                      </mapper>
+                    </data>
+                  </dataSet>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
         </includes>
       </resource>
       <resource>
-        <directory>${basedir}/templates</directory>
+        <directory>${project.basedir}/templates</directory>
         <targetPath>${project.build.directory}</targetPath>
         <filtering>true</filtering>
         <includes>

--- a/templates/control
+++ b/templates/control
@@ -1,7 +1,8 @@
-Package: ${project.artifactId}
-Version: ${project.version}
+Package: [[artifactId]]
+Version: [[version]]
 Section: contrib/utils
 Priority: optional
 Architecture: all
+Depends: openjdk-7-jre | openjdk-8-jre | oracle-java7-jre | oracle-java8-jre, git (>=1.9)
 Maintainer: Microsoft http://www.microsoft.com/
-Description: ${project.description}
+Description: [[description]]

--- a/templates/control
+++ b/templates/control
@@ -1,0 +1,7 @@
+Package: ${project.artifactId}
+Version: ${project.version}
+Section: contrib/utils
+Priority: optional
+Architecture: all
+Maintainer: Microsoft http://www.microsoft.com/
+Description: ${project.description}


### PR DESCRIPTION
This addition creates a Debian package that can be installed on Debian platforms (i.e. Ubuntu). This will only occur when built as a release. A control file is needed for creation so that is added as a template that gets dynamically populated with the latest project info. 

# Manual Tests
* Tested building the project not as release and no deb file was created (on Fedora machine)
* Tested building the project as a release and a deb file was created (on Fedora machine)
    * Moved the deb file to an Ubuntu machine and ran: `sudo dpkg -i <package>`
    * Was able to call: `git-credential-manager install/uninstall`
    * Tried to install the deb package without the proper git/java versions and it failed