### PR TITLE
Ensure clean separation between re-usable code and GCM app

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
@@ -6,7 +6,6 @@ package com.microsoft.alm.authentication;
 import com.microsoft.alm.helpers.Action;
 import com.microsoft.alm.helpers.Debug;
 import com.microsoft.alm.helpers.Guid;
-import com.microsoft.alm.gitcredentialmanager.InsecureStore;
 import com.microsoft.alm.helpers.HttpClient;
 import com.microsoft.alm.helpers.StringHelper;
 import com.microsoft.alm.helpers.Trace;
@@ -41,7 +40,7 @@ public abstract class BaseVsoAuthentication extends BaseAuthentication
         this.TokenScope = tokenScope;
         this.VsoIdeTokenCache = vsoIdeTokenCache;
         this.PersonalAccessTokenStore = personalAccessTokenStore;
-        this.AdaRefreshTokenStore = adaRefreshTokenStore != null ? adaRefreshTokenStore : new SecretStore(new InsecureStore() /* TODO: 449201: replace with an appropriate ISecureStore */, AdalRefreshPrefix);
+        this.AdaRefreshTokenStore = adaRefreshTokenStore != null ? adaRefreshTokenStore : new SecretCache(AdalRefreshPrefix);
         this.VsoAuthority = vsoAuthority;
     }
     /**
@@ -57,7 +56,7 @@ public abstract class BaseVsoAuthentication extends BaseAuthentication
             final ITokenStore adaRefreshTokenStore
     )
     {
-        this(tokenScope, personalAccessTokenStore, new SecretStore(new InsecureStore(), "registry") /* TODO: 449222: replace with a TokenRegistry implementation */, adaRefreshTokenStore, new VsoAzureAuthority());
+        this(tokenScope, personalAccessTokenStore, new SecretCache("registry"), adaRefreshTokenStore, new VsoAzureAuthority());
     }
     BaseVsoAuthentication(
             final ICredentialStore personalAccessTokenStore,

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
@@ -42,7 +42,10 @@ public class InsecureStore implements ISecureStore
 
     /**
      * Creates an instance that only keeps the values in memory, never touching a file.
+     *
+     * @deprecated If you need an in-memory store, use SecretCache.
      */
+    @Deprecated
     public InsecureStore()
     {
         this(null);
@@ -126,7 +129,7 @@ public class InsecureStore implements ISecureStore
     {
         try
         {
-            final InsecureStore result = new InsecureStore();
+            final InsecureStore result = new InsecureStore(null);
             final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             final DocumentBuilder builder = dbf.newDocumentBuilder();
             final Document document = builder.parse(source);

--- a/src/test/java/com/microsoft/alm/authentication/TokenTest.java
+++ b/src/test/java/com/microsoft/alm/authentication/TokenTest.java
@@ -5,7 +5,6 @@ package com.microsoft.alm.authentication;
 
 import com.microsoft.alm.helpers.BitConverter;
 import com.microsoft.alm.helpers.Guid;
-import com.microsoft.alm.gitcredentialmanager.InsecureStore;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,17 +20,17 @@ public class TokenTest
     @Test
     public void tokenStoreUrl() throws URISyntaxException
     {
-        tokenStoreTest(new SecretStore(new InsecureStore(), "test-token"), "http://dummy.url/for/testing", TokenString);
+        tokenStoreTest(new SecretCache("test-token"), "http://dummy.url/for/testing", TokenString);
     }
     @Test
     public void tokenStoreUrlWithParams() throws URISyntaxException
     {
-        tokenStoreTest(new SecretStore(new InsecureStore(), "test-token"), "http://dummy.url/for/testing?with=params", TokenString);
+        tokenStoreTest(new SecretCache("test-token"), "http://dummy.url/for/testing?with=params", TokenString);
     }
     @Test
     public void tokenStoreUnc() throws URISyntaxException
     {
-        tokenStoreTest(new SecretStore(new InsecureStore(), "test-token"), "file://unc/share/test", TokenString);
+        tokenStoreTest(new SecretCache("test-token"), "file://unc/share/test", TokenString);
     }
     @Test
     public void tokenCacheUrl() throws URISyntaxException

--- a/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
+++ b/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
@@ -24,7 +24,7 @@ public class InsecureStoreTest
      */
     @Test public void delete_noMatchingTokenOrCredential()
     {
-        final InsecureStore cut = new InsecureStore();
+        final InsecureStore cut = new InsecureStore(null);
 
         cut.delete("foo");
     }
@@ -66,7 +66,7 @@ public class InsecureStoreTest
 
     @Test public void serialization_instanceToXmlToInstance()
     {
-        final InsecureStore input = new InsecureStore();
+        final InsecureStore input = new InsecureStore(null);
         final Token inputBravo = new Token("42", TokenType.Test);
         input.Tokens.put("alpha", null);
         input.Tokens.put("bravo", inputBravo);


### PR DESCRIPTION
This PR removes references from the `authentication` package to the `gitcredentialmanager` package, making it easier to extract the `authentication` and `helpers` packages into a re-usable library.

It turns out the only uses going the "wrong way" were of the `InsecureStore` and they really were only using it as an in-memory store, something that the `SecretCache` already provides.