### PR TITLE
Improve KeychainSecurityCliStore and then wire it up on Mac OS X

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
+++ b/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
@@ -31,6 +31,7 @@ public class KeychainSecurityCliStore implements ISecureStore
     private static final String SERVICE_PARAMETER = "-s";
     private static final String KIND_PARAMETER = "-D";
     private static final String PASSWORD_PARAMETER = "-w";
+    private static final String UPDATE_IF_ALREADY_EXISTS = "-U";
 
     enum SecretKind
     {
@@ -406,18 +407,10 @@ public class KeychainSecurityCliStore implements ISecureStore
         final String stdOut, stdErr;
         try
         {
-            final TestableProcess deleteProcess = processFactory.create(
-                SECURITY,
-                DELETE_GENERIC_PASSWORD,
-                SERVICE_PARAMETER, serviceName,
-                KIND_PARAMETER, secretKind.name()
-            );
-            // we don't care about the exit code
-            deleteProcess.waitFor();
-
             final TestableProcess addProcess = processFactory.create(
                 SECURITY,
                 ADD_GENERIC_PASSWORD,
+                UPDATE_IF_ALREADY_EXISTS,
                 ACCOUNT_PARAMETER, accountName,
                 SERVICE_PARAMETER, serviceName,
                 PASSWORD_PARAMETER, password,

--- a/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
+++ b/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
@@ -32,6 +32,7 @@ public class KeychainSecurityCliStore implements ISecureStore
     private static final String KIND_PARAMETER = "-D";
     private static final String PASSWORD_PARAMETER = "-w";
     private static final String UPDATE_IF_ALREADY_EXISTS = "-U";
+    private static final int ITEM_NOT_FOUND_EXIT_CODE = 44;
 
     enum SecretKind
     {
@@ -355,7 +356,10 @@ public class KeychainSecurityCliStore implements ISecureStore
             final int result = coordinator.waitFor();
             stdOut = coordinator.getStdOut();
             stdErr = coordinator.getStdErr();
-            checkResult(result, stdOut, stdErr);
+            if (result != 0 && result != ITEM_NOT_FOUND_EXIT_CODE)
+            {
+                checkResult(result, stdOut, stdErr);
+            }
         }
         catch (final IOException e)
         {
@@ -379,10 +383,18 @@ public class KeychainSecurityCliStore implements ISecureStore
 
         final Map<String, Object> metaData = read(SecretKind.Credential, processFactory, serviceName);
 
-        final String userName = (String) metaData.get(ACCOUNT_METADATA);
-        final String password = (String) metaData.get(PASSWORD);
+        final Credential result;
+        if (metaData.size() > 0)
+        {
+            final String userName = (String) metaData.get(ACCOUNT_METADATA);
+            final String password = (String) metaData.get(PASSWORD);
 
-        final Credential result = new Credential(userName, password);
+            result = new Credential(userName, password);
+        }
+        else
+        {
+            result = null;
+        }
 
         return result;
     }
@@ -394,10 +406,18 @@ public class KeychainSecurityCliStore implements ISecureStore
 
         final Map<String, Object> metaData = read(SecretKind.Token, processFactory, serviceName);
 
-        final String password = (String) metaData.get(PASSWORD);
-        final String typeName = (String) metaData.get(ACCOUNT_METADATA);
+        final Token result;
+        if (metaData.size() > 0)
+        {
+            final String typeName = (String) metaData.get(ACCOUNT_METADATA);
+            final String password = (String) metaData.get(PASSWORD);
 
-        final Token result = new Token(password, typeName);
+            result = new Token(password, typeName);
+        }
+        else
+        {
+            result = null;
+        }
 
         return result;
     }

--- a/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
+++ b/src/main/java/com/microsoft/alm/authentication/KeychainSecurityCliStore.java
@@ -24,6 +24,7 @@ public class KeychainSecurityCliStore implements ISecureStore
     static final String DELETE_GENERIC_PASSWORD = "delete-generic-password";
     static final String FIND_GENERIC_PASSWORD = "find-generic-password";
     static final String ADD_GENERIC_PASSWORD = "add-generic-password";
+    static final String SHOW_KEYCHAIN_INFO = "show-keychain-info";
     static final String ACCOUNT_PARAMETER = "-a";
     static final String ACCOUNT_METADATA = "acct";
     static final String PASSWORD = "password";
@@ -309,17 +310,31 @@ public class KeychainSecurityCliStore implements ISecureStore
 
     public boolean isKeychainAvailable()
     {
-        final String targetName = "test:isKeychainAvailable";
-        final Token token = new Token("this is a test token", TokenType.Test);
+        final String stdOut, stdErr;
         try
         {
-            writeToken(targetName, token);
+            final TestableProcess process = processFactory.create(
+                SECURITY,
+                SHOW_KEYCHAIN_INFO
+            );
+            final ProcessCoordinator coordinator = new ProcessCoordinator(process);
+            final int result = coordinator.waitFor();
+            stdOut = coordinator.getStdOut();
+            stdErr = coordinator.getStdErr();
+            checkResult(result, stdOut, stdErr);
+        }
+        catch (final IOException e)
+        {
+            throw new Error(e);
+        }
+        catch (final InterruptedException e)
+        {
+            throw new Error(e);
         }
         catch (final SecurityException e)
         {
             return false;
         }
-        delete(targetName);
         return true;
     }
 

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/IComponentFactory.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/IComponentFactory.java
@@ -13,5 +13,5 @@ public interface IComponentFactory
 {
     IAuthentication createAuthentication(final OperationArguments operationArguments, final ISecureStore secureStore);
     Configuration createConfiguration() throws IOException;
-    ISecureStore createSecureStore();
+    ISecureStore createSecureStore(final OperationArguments operationArguments);
 }

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
@@ -38,6 +38,8 @@ public class InsecureStore implements ISecureStore
     final Map<String, Token> Tokens = new HashMap<String, Token>();
     final Map<String, Credential> Credentials = new HashMap<String, Credential>();
 
+    private boolean isEnabled = true;
+
     /**
      * Creates an instance that only keeps the values in memory, never touching a file.
      *
@@ -293,9 +295,19 @@ public class InsecureStore implements ISecureStore
         return credentialsNode;
     }
 
+    private void ensureEnabled()
+    {
+        if (!isEnabled)
+        {
+            throw new IllegalStateException("This InsecureStore has been disabled.");
+        }
+    }
+
     @Override
     public synchronized void delete(final String targetName)
     {
+        ensureEnabled();
+
         if (Tokens.containsKey(targetName))
         {
             Tokens.remove(targetName);
@@ -311,18 +323,24 @@ public class InsecureStore implements ISecureStore
     @Override
     public synchronized Credential readCredentials(final String targetName)
     {
+        ensureEnabled();
+
         return Credentials.get(targetName);
     }
 
     @Override
     public synchronized Token readToken(final String targetName)
     {
+        ensureEnabled();
+
         return Tokens.get(targetName);
     }
 
     @Override
     public synchronized void writeCredential(final String targetName, final Credential credentials)
     {
+        ensureEnabled();
+
         Credentials.put(targetName, credentials);
         save();
     }
@@ -330,6 +348,8 @@ public class InsecureStore implements ISecureStore
     @Override
     public synchronized void writeToken(final String targetName, final Token token)
     {
+        ensureEnabled();
+
         Tokens.put(targetName, token);
         save();
     }

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
@@ -384,6 +384,7 @@ public class InsecureStore implements ISecureStore
 
         if (backingFile != null)
         {
+            // TODO: Add a parameter to control whether a rename or a delete should take place
             final File disabledBackingFile = new File(backingFile.getAbsolutePath() + MIGRATION_SUFFIX);
             final boolean wasRenamed = backingFile.renameTo(disabledBackingFile);
             if (!wasRenamed)

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/OperationArguments.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/OperationArguments.java
@@ -99,6 +99,8 @@ final class OperationArguments
 
     public boolean EraseOsxKeyChain;
 
+    public boolean CanFallbackToInsecureStore;
+
     public void setCredentials(final Credential credentials)
     {
         this.userName = credentials.Username;

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -1174,13 +1174,20 @@ public class Program
 
         @Override public ISecureStore createSecureStore()
         {
-            // TODO: 449516: detect the operating system/capabilities and create the appropriate instance
+            ISecureStore secureStore = null;
             final File parentFolder = determineParentFolder();
             final File programFolder = new File(parentFolder, ProgramFolderName);
-            //noinspection ResultOfMethodCallIgnored
-            programFolder.mkdirs();
             final File insecureFile = new File(programFolder, "insecureStore.xml");
-            return new InsecureStore(insecureFile);
+
+            // TODO: 449516: detect the operating system/capabilities and create the appropriate instance
+
+            if (secureStore == null)
+            {
+                //noinspection ResultOfMethodCallIgnored
+                programFolder.mkdirs();
+                secureStore = new InsecureStore(insecureFile);
+            }
+            return secureStore;
         }
     }
 }

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -897,7 +897,7 @@ public class Program
         Trace.writeLine("Program::" + methodName);
         Trace.writeLine("   targetUri = " + operationArguments.TargetUri);
 
-        final ISecureStore secureStore = componentFactory.createSecureStore();
+        final ISecureStore secureStore = componentFactory.createSecureStore(operationArguments);
         final IAuthentication authentication = componentFactory.createAuthentication(operationArguments, secureStore);
 
         operationArgumentsRef.set(operationArguments);
@@ -1172,7 +1172,7 @@ public class Program
             return new Configuration();
         }
 
-        @Override public ISecureStore createSecureStore()
+        @Override public ISecureStore createSecureStore(final OperationArguments operationArguments)
         {
             ISecureStore secureStore = null;
             final File parentFolder = determineParentFolder();

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -12,6 +12,7 @@ import com.microsoft.alm.authentication.ISecureStore;
 import com.microsoft.alm.authentication.ITokenStore;
 import com.microsoft.alm.authentication.IVsoAadAuthentication;
 import com.microsoft.alm.authentication.IVsoMsaAuthentication;
+import com.microsoft.alm.authentication.KeychainSecurityCliStore;
 import com.microsoft.alm.authentication.SecretStore;
 import com.microsoft.alm.authentication.VsoAadAuthentication;
 import com.microsoft.alm.authentication.VsoMsaAuthentication;
@@ -63,6 +64,7 @@ public class Program
     private static final String AbortAuthenticationProcessResponse = "quit=true";
     private static final String CredentialHelperSection = "credential.helper";
     private static final String CredentialHelperValueRegex = "git-credential-manager-[0-9]+\\.[0-9]+\\.[0-9]+(-SNAPSHOT)?.jar";
+    private static final String CanFallbackToInsecureStore = "canFallBackToInsecureStore";
     private static final DefaultFileChecker DefaultFileCheckerSingleton = new DefaultFileChecker();
 
     private final InputStream standardIn;
@@ -1081,6 +1083,20 @@ public class Program
                 operationArguments.EraseOsxKeyChain = false;
             }
         }
+
+        if (config.tryGetEntry(ConfigPrefix, operationArguments.TargetUri, CanFallbackToInsecureStore, entryRef))
+        {
+            Trace.writeLine("   " + CanFallbackToInsecureStore + " = " + entryRef.get().Value);
+
+            if ("true".equalsIgnoreCase(entryRef.get().Value))
+            {
+                operationArguments.CanFallbackToInsecureStore = true;
+            }
+            else if ("false".equalsIgnoreCase(entryRef.get().Value))
+            {
+                operationArguments.CanFallbackToInsecureStore = false;
+            }
+        }
     }
 
     private static void logEvent(final String message, final Object eventType)
@@ -1174,15 +1190,52 @@ public class Program
 
         @Override public ISecureStore createSecureStore(final OperationArguments operationArguments)
         {
+            Trace.writeLine("Program::ComponentFactory::createSecureStore");
             ISecureStore secureStore = null;
             final File parentFolder = determineParentFolder();
             final File programFolder = new File(parentFolder, ProgramFolderName);
             final File insecureFile = new File(programFolder, "insecureStore.xml");
 
-            // TODO: 449516: detect the operating system/capabilities and create the appropriate instance
+            final String osName = System.getProperty("os.name");
+            if (Provider.isMac(osName))
+            {
+                Trace.writeLine("   Mac OS X detected");
+                final KeychainSecurityCliStore keychainSecurityCliStore = new KeychainSecurityCliStore();
+                boolean ableToUseKeychain = keychainSecurityCliStore.isKeychainAvailable();
+                boolean canFallbackToInsecureStore = operationArguments.CanFallbackToInsecureStore;
+                if (ableToUseKeychain)
+                {
+                    Trace.writeLine("     Keychain is available");
+                    secureStore = keychainSecurityCliStore;
+                    if (insecureFile.isFile())
+                    {
+                        Trace.writeLine("       InsecureStore file found");
+                        if (!canFallbackToInsecureStore /* in other words, we won't use it again */)
+                        {
+                            Trace.writeLine("         No fallback requested, migrating...");
+                            final InsecureStore insecureStore = new InsecureStore(insecureFile);
+                            insecureStore.migrateAndDisable(secureStore);
+                            Trace.writeLine("         Migrated and disabled.");
+                        }
+                        else
+                        {
+                            Trace.writeLine("         Fallback requested, skipping migration.");
+                        }
+                    }
+                }
+                else
+                {
+                    Trace.writeLine("     Keychain is NOT available");
+                    if (!canFallbackToInsecureStore)
+                    {
+                        throw new SecurityException("The Keychain is not available. If you would like to use the InsecureStore instead, run `git config credential.canfallbacktoinsecurestore true`");
+                    }
+                }
+            }
 
             if (secureStore == null)
             {
+                Trace.writeLine("   Using the InsecureStore");
                 //noinspection ResultOfMethodCallIgnored
                 programFolder.mkdirs();
                 secureStore = new InsecureStore(insecureFile);

--- a/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
@@ -168,6 +168,12 @@ attributes:
             expectedExitCode = 44
         }
 
+        def findNoCredential = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
+        findNoCredential.with {
+            expectedCommand = ["/usr/bin/security", "find-generic-password", "-s", SERVICE_NAME, "-D", "Credential", "-g"]
+            expectedExitCode = 44
+        }
+
         def addCredential = new FifoProcess(StringHelper.Empty)
         addCredential.with {
             expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Credential"]
@@ -206,6 +212,12 @@ attributes:
             expectedExitCode = 44
         }
 
+        def findNoToken = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
+        findNoToken.with {
+            expectedCommand = ["/usr/bin/security", "find-generic-password", "-s", SERVICE_NAME, "-D", "Token", "-g"]
+            expectedExitCode = 44
+        }
+
         def addToken = new FifoProcess(StringHelper.Empty)
         addToken.with {
             expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Token"]
@@ -235,12 +247,14 @@ attributes:
         def processFactory = new FifoProcessFactory(
             deleteCredentialSuccess,
             deleteCredentialFailure,
+            findNoCredential,
             addCredential,
             findCredential,
             updateCredential,
             findUpdatedCredential,
             deleteTokenSuccess,
             deleteTokenFailure,
+            findNoToken,
             addToken,
             findToken,
             updateToken,
@@ -264,6 +278,10 @@ attributes:
         // there should be nothing there, yet this call should not fail
         store.delete(TARGET_NAME)
 
+        final def nullCredential = store.readCredentials(TARGET_NAME)
+
+        assert nullCredential == null
+
         store.writeCredential(TARGET_NAME, credential)
 
         final def actualCredential = store.readCredentials(TARGET_NAME)
@@ -285,6 +303,10 @@ attributes:
         store.delete(TARGET_NAME)
         // there should be nothing there, yet this call should not fail
         store.delete(TARGET_NAME)
+
+        final def nullToken = store.readToken(TARGET_NAME)
+
+        assert nullToken == null
 
         store.writeToken(TARGET_NAME, token)
 

--- a/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
@@ -168,15 +168,9 @@ attributes:
             expectedExitCode = 44
         }
 
-        def deleteBeforeAddCredential = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
-        deleteBeforeAddCredential.with {
-            expectedCommand = ["/usr/bin/security", "delete-generic-password", "-s", SERVICE_NAME, "-D", "Credential"]
-            expectedExitCode = 44
-        }
-
         def addCredential = new FifoProcess(StringHelper.Empty)
         addCredential.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Credential"]
+            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Credential"]
             expectedExitCode = 0
         }
 
@@ -187,15 +181,9 @@ attributes:
             expectedExitCode = 0
         }
 
-        def deleteBeforeUpdateCredential = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
-        deleteBeforeUpdateCredential.with {
-            expectedCommand = ["/usr/bin/security", "delete-generic-password", "-s", SERVICE_NAME, "-D", "Credential"]
-            expectedExitCode = 44
-        }
-
         def updateCredential = new FifoProcess(StringHelper.Empty)
         updateCredential.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Credential"]
+            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Credential"]
             expectedExitCode = 0
         }
 
@@ -218,15 +206,9 @@ attributes:
             expectedExitCode = 44
         }
 
-        def deleteBeforeAddToken = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
-        deleteBeforeAddToken.with {
-            expectedCommand = ["/usr/bin/security", "delete-generic-password", "-s", SERVICE_NAME, "-D", "Token"]
-            expectedExitCode = 44
-        }
-
         def addToken = new FifoProcess(StringHelper.Empty)
         addToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Token"]
+            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Token"]
             expectedExitCode = 0
         }
 
@@ -237,15 +219,9 @@ attributes:
             expectedExitCode = 0
         }
 
-        def deleteBeforeUpdateToken = new FifoProcess(StringHelper.Empty, "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
-        deleteBeforeUpdateToken.with {
-            expectedCommand = ["/usr/bin/security", "delete-generic-password", "-s", SERVICE_NAME, "-D", "Token"]
-            expectedExitCode = 44
-        }
-
         def updateToken = new FifoProcess(StringHelper.Empty)
         updateToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Token"]
+            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Token"]
             expectedExitCode = 0
         }
 
@@ -259,18 +235,14 @@ attributes:
         def processFactory = new FifoProcessFactory(
             deleteCredentialSuccess,
             deleteCredentialFailure,
-            deleteBeforeAddCredential,
             addCredential,
             findCredential,
-            deleteBeforeUpdateCredential,
             updateCredential,
             findUpdatedCredential,
             deleteTokenSuccess,
             deleteTokenFailure,
-            deleteBeforeAddToken,
             addToken,
             findToken,
-            deleteBeforeUpdateToken,
             updateToken,
             findUpdatedToken,
         )

--- a/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
@@ -157,34 +157,27 @@ attributes:
     }
 
     @Test public void simulatedProbing_keychainIsAvailable() {
-        def addToken = new FifoProcess(StringHelper.Empty)
-        addToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Test-only Token", "-s", "gcm4ml:test:isKeychainAvailable", "-w", "this is a test token", "-D", "Token"]
-            expectedExitCode = 0
-        }
-
-        def deleteTokenSuccess = new FifoProcess(SAMPLE_TOKEN_METADATA, "password has been deleted.")
-        deleteTokenSuccess.with {
-            expectedCommand = ["/usr/bin/security", "delete-generic-password", "-s", "gcm4ml:test:isKeychainAvailable"]
+        def showInfo = new FifoProcess(StringHelper.Empty)
+        showInfo.with {
+            expectedCommand = ["/usr/bin/security", "show-keychain-info"]
             expectedExitCode = 0
         }
 
         def processFactory = new FifoProcessFactory(
-            addToken,
-            deleteTokenSuccess,
+            showInfo,
         )
         probingTest(processFactory, true)
     }
 
     @Test public void simulatedProbing_keychainIsNotAvailable() {
-        def addToken = new FifoProcess(StringHelper.Empty)
-        addToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Test-only Token", "-s", "gcm4ml:test:isKeychainAvailable", "-w", "this is a test token", "-D", "Token"]
+        def showInfo = new FifoProcess(StringHelper.Empty)
+        showInfo.with {
+            expectedCommand = ["/usr/bin/security", "show-keychain-info"]
             expectedExitCode = 36
         }
 
         def processFactory = new FifoProcessFactory(
-                addToken,
+                showInfo,
         )
         probingTest(processFactory, false)
     }

--- a/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
+++ b/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.gitcredentialmanager;
 
 import com.microsoft.alm.authentication.Credential;
+import com.microsoft.alm.authentication.ISecureStore;
 import com.microsoft.alm.authentication.Token;
 import com.microsoft.alm.authentication.TokenType;
 import com.microsoft.alm.helpers.IOHelper;
@@ -74,14 +75,14 @@ public class InsecureStoreTest
         verifyTestData(actual);
     }
 
-    private static void initializeTestData(final InsecureStore input)
+    private static void initializeTestData(final ISecureStore input)
     {
         final Token inputBravo = new Token("42", TokenType.Test);
-        input.Tokens.put("alpha", null);
-        input.Tokens.put("bravo", inputBravo);
-        input.Credentials.put("charlie", null);
+        input.writeToken("alpha", null);
+        input.writeToken("bravo", inputBravo);
+        input.writeCredential("charlie", null);
         final Credential inputDelta = new Credential("douglas.adams", "42");
-        input.Credentials.put("delta", inputDelta);
+        input.writeCredential("delta", inputDelta);
     }
 
     private void verifyTestData(final InsecureStore actual)

--- a/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
+++ b/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
@@ -67,15 +67,25 @@ public class InsecureStoreTest
     @Test public void serialization_instanceToXmlToInstance()
     {
         final InsecureStore input = new InsecureStore(null);
+        initializeTestData(input);
+
+        final InsecureStore actual = clone(input);
+
+        verifyTestData(actual);
+    }
+
+    private static void initializeTestData(final InsecureStore input)
+    {
         final Token inputBravo = new Token("42", TokenType.Test);
         input.Tokens.put("alpha", null);
         input.Tokens.put("bravo", inputBravo);
         input.Credentials.put("charlie", null);
         final Credential inputDelta = new Credential("douglas.adams", "42");
         input.Credentials.put("delta", inputDelta);
+    }
 
-        final InsecureStore actual = clone(input);
-
+    private void verifyTestData(final InsecureStore actual)
+    {
         Assert.assertEquals(2, actual.Tokens.size());
         Assert.assertTrue(actual.Tokens.containsKey("alpha"));
         final Token actualBravo = actual.Tokens.get("bravo");

--- a/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
+++ b/src/test/java/com/microsoft/alm/gitcredentialmanager/InsecureStoreTest.java
@@ -75,6 +75,47 @@ public class InsecureStoreTest
         verifyTestData(actual);
     }
 
+    @Test public void migrateAndDisable_noBackingFile()
+    {
+        final InsecureStore input = new InsecureStore(null);
+        initializeTestData(input);
+        final InsecureStore actual = new InsecureStore(null);
+
+        input.migrateAndDisable(actual);
+
+        verifyTestData(actual);
+    }
+
+    @Test public void migrateAndDisable_withBackingFile() throws Exception
+    {
+        File tempFile = null;
+        try
+        {
+            tempFile = File.createTempFile(this.getClass().getSimpleName(), null);
+            Assert.assertEquals(0L, tempFile.length());
+
+            final InsecureStore input = new InsecureStore(tempFile);
+            initializeTestData(input);
+            Assert.assertNotEquals(0L, tempFile.length());
+            final InsecureStore actual = new InsecureStore(null);
+
+            input.migrateAndDisable(actual);
+
+            verifyTestData(actual);
+            Assert.assertFalse(tempFile.isFile());
+            final File migratedFile = new File(tempFile.getAbsolutePath() + InsecureStore.MIGRATION_SUFFIX);
+            Assert.assertTrue(migratedFile.isFile());
+            //noinspection ResultOfMethodCallIgnored
+            migratedFile.delete();
+        }
+        finally
+        {
+            if (tempFile != null)
+                //noinspection ResultOfMethodCallIgnored
+                tempFile.delete();
+        }
+    }
+
     private static void initializeTestData(final ISecureStore input)
     {
         final Token inputBravo = new Token("42", TokenType.Test);


### PR DESCRIPTION
During testing, I noticed a few small improvements that could be made, so I included them as part of this pull request:

1. The `add-generic-password` command has an _update_ mode (`-U`) that avoids having to delete-then-add. (b7b1d4a)
2. Asking for a token or credential that does not exist will now return `null`. ( 41dd00b)
3. If the `insecureStore.xml` file exists, its entries will be imported and the file renamed to add a `.old` suffix. (6bf68ba)
4. Added a check to see if the keychain is available (it isn't through a remote shell, for example, unless it's been unlocked). If the keychain is not available, there's a configurable [opt-in] fallback to the `InsecureStore`, otherwise a `SecurityException` is thrown to fail as early as possible. (12c0766)

Manual testing
--------------
Installed (in debug mode) on a Mac Mini running OS X version 10.10.5, then, using an HTTPS clone of this repo:

1. From a remote shell, ran `git push`. In `stderr`, one could read the following:

    ```
Program::ComponentFactory::createSecureStore
   Mac OS X detected
     Keychain is NOT available
Fatal error encountered.  Details:
java.lang.SecurityException: The Keychain is not available. If you would like to use the InsecureStore instead, run `git config credential.canfallbacktoinsecurestore true`
        at com.microsoft.alm.gitcredentialmanager.Program$ComponentFactory.createSecureStore(Program.java:1227)
(...)
        at com.microsoft.alm.gitcredentialmanager.Program.main(Program.java:104)
fatal: credential helper '!java -Ddebug=true -jar /Users/olivida/Downloads/with\ spaces/git-credential-manager-1.3.1-SNAPSHOT.jar' told us to quit
    ```
2. Again in the remote shell, ran `git config credential.canfallbacktoinsecurestore true`, followed by `git push`.  This time, `stderr` contained the following and authentication proceeded successfully:

    ```
Program::ComponentFactory::createSecureStore
   Mac OS X detected
     Keychain is NOT available
   Using the InsecureStore
    ```
3. In a desktop terminal (iTerm), ran `git push` and `stderr` contained the following, soon before I was asked to provide credentials by Git:

    ```
Program::ComponentFactory::createSecureStore
   Mac OS X detected
     Keychain is available
       InsecureStore file found
         Fallback requested, skipping migration.
    ```
4. Again in the desktop terminal, ran ` git config credential.canfallbacktoinsecurestore false`, followed by a `git push`.  I could see `stderr` contained the following, before I was successfully authenticated:

    ```
Program::ComponentFactory::createSecureStore
   Mac OS X detected
     Keychain is available
       InsecureStore file found
         No fallback requested, migrating...
         Migrated and disabled.
    ```
5. Verified that `~/git-credential-manager/insecureStore.xml` had been renamed to `~/git-credential-manager/insecureStore.xml.old` and that the Keychain now contained three new entries, imported from said file.  One last `git push` and `stderr` contained the following before I was authenticated:

    ```
Program::ComponentFactory::createSecureStore
   Mac OS X detected
     Keychain is available
    ```

Mission accomplished!