### PR TITLE
Use security in interactive mode for adding

### DIFF
--- a/src/main/java/com/microsoft/alm/helpers/StringHelper.java
+++ b/src/main/java/com/microsoft/alm/helpers/StringHelper.java
@@ -98,6 +98,26 @@ public class StringHelper
      */
     public static String join(final String separator, final String[] value, final int startIndex, final int count)
     {
+        return join(separator, value, startIndex, count, null);
+    }
+
+    /**
+     * Concatenates the specified elements of a string array,
+     * using the specified separator between each element.
+     *
+     * @param separator  The string to use as a separator.
+     *                   separator is included in the returned string only if value has more than one element.
+     * @param value      An array that contains the elements to concatenate.
+     * @param startIndex The first element in value to use.
+     * @param count      The number of elements of value to use.
+     * @param processor  A callback that gets to intercept and modify elements before they are inserted.
+     * @return           A string that consists of the strings in value delimited by the separator string.
+     *                   -or-
+     *                   {@link StringHelper#Empty} if count is zero, value has no elements,
+     *                   or separator and all the elements of value are {@link StringHelper#Empty}.
+     */
+    public static String join(final String separator, final String[] value, final int startIndex, final int count, final Func<String, String> processor)
+    {
         if (value == null)
             throw new IllegalArgumentException("value is null");
         if (startIndex < 0)
@@ -114,11 +134,21 @@ public class StringHelper
 
         if (value.length > 0 && count > 0)
         {
-            result.append(ObjectExtensions.coalesce(value[startIndex], StringHelper.Empty));
+            String element = ObjectExtensions.coalesce(value[startIndex], StringHelper.Empty);
+            if (processor != null)
+            {
+                element = processor.call(element);
+            }
+            result.append(element);
             for (int i = startIndex + 1; i < startIndex + count; i++)
             {
                 result.append(sep);
-                result.append(ObjectExtensions.coalesce(value[i], StringHelper.Empty));
+                element = ObjectExtensions.coalesce(value[i], StringHelper.Empty);
+                if (processor != null)
+                {
+                    element = processor.call(element);
+                }
+                result.append(element);
             }
         }
 

--- a/src/test/groovy/com/microsoft/alm/authentication/FifoProcess.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/FifoProcess.groovy
@@ -11,6 +11,7 @@ class FifoProcess extends TestProcess {
 
     String[] expectedCommand = null;
     int expectedExitCode = 0;
+    String expectedStandardInput = null;
 
     public FifoProcess(final String input) {
         super(input)
@@ -22,6 +23,10 @@ class FifoProcess extends TestProcess {
 
     @Override
     int waitFor() throws InterruptedException {
+        if (expectedStandardInput != null) {
+            final def actualStandardInput = getOutput()
+            assert actualStandardInput == expectedStandardInput
+        }
         return expectedExitCode
     }
 }

--- a/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/KeychainSecurityCliStoreTest.groovy
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.authentication
 
+import com.microsoft.alm.helpers.Environment
 import com.microsoft.alm.helpers.StringHelper
 import com.microsoft.alm.oauth2.useragent.subprocess.DefaultProcessFactory
 import com.microsoft.alm.oauth2.useragent.subprocess.TestableProcessFactory
@@ -216,7 +217,8 @@ attributes:
 
         def addCredential = new FifoProcess(StringHelper.Empty)
         addCredential.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Credential"]
+            expectedCommand = ["/usr/bin/security", "-i"]
+            expectedStandardInput = """add-generic-password -U -a ${USER_NAME} -s ${SERVICE_NAME} -w ${PASSWORD} -D Credential""" + Environment.NewLine
             expectedExitCode = 0
         }
 
@@ -229,7 +231,8 @@ attributes:
 
         def updateCredential = new FifoProcess(StringHelper.Empty)
         updateCredential.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", USER_NAME, "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Credential"]
+            expectedCommand = ["/usr/bin/security", "-i"]
+            expectedStandardInput = """add-generic-password -U -a ${USER_NAME} -s ${SERVICE_NAME} -w "${PASSWORD2}" -D Credential""" + Environment.NewLine
             expectedExitCode = 0
         }
 
@@ -260,7 +263,8 @@ attributes:
 
         def addToken = new FifoProcess(StringHelper.Empty)
         addToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD, "-D", "Token"]
+            expectedCommand = ["/usr/bin/security", "-i"]
+            expectedStandardInput = """add-generic-password -U -a "Personal Access Token" -s ${SERVICE_NAME} -w ${PASSWORD} -D Token""" + Environment.NewLine
             expectedExitCode = 0
         }
 
@@ -273,7 +277,8 @@ attributes:
 
         def updateToken = new FifoProcess(StringHelper.Empty)
         updateToken.with {
-            expectedCommand = ["/usr/bin/security", "add-generic-password", "-U", "-a", "Personal Access Token", "-s", SERVICE_NAME, "-w", PASSWORD2, "-D", "Token"]
+            expectedCommand = ["/usr/bin/security", "-i"]
+            expectedStandardInput = """add-generic-password -U -a "Personal Access Token" -s ${SERVICE_NAME} -w "${PASSWORD2}" -D Token""" + Environment.NewLine
             expectedExitCode = 0
         }
 

--- a/src/test/java/com/microsoft/alm/helpers/StringHelperTest.java
+++ b/src/test/java/com/microsoft/alm/helpers/StringHelperTest.java
@@ -129,6 +129,26 @@ public class StringHelperTest
         Assert.assertEquals(StringHelper.Empty, StringHelper.join(StringHelper.Empty, arrayOfEmpty, 0, 3));
     }
 
+    @Test public void join_withQuotingProcessor()
+    {
+        final Func<String, String> quotingProcessor = new Func<String, String>()
+        {
+            @Override public String call(final String s)
+            {
+                if (s.contains(" "))
+                {
+                    return '"' + s + '"';
+                }
+                return s;
+            }
+        };
+        final String[] args = {"--user", "man-with-hat", "--password", "battery horse staple correct"};
+
+        final String actual = StringHelper.join(" ", args, 0, args.length, quotingProcessor);
+
+        Assert.assertEquals("--user man-with-hat --password \"battery horse staple correct\"", actual);
+    }
+
     @Test public void trimEnd_documentationExample()
     {
         final String actual = StringHelper.trimEnd("123abc456xyz789", '1', '2', '3', '4', '5', '6', '7', '8', '9');


### PR DESCRIPTION
This avoids having the password be a command-line argument, which could be seen in the list of running processes, etc.  Inspired by jaraco/keyring#165

Manual testing
--------------
Ran the ignored tests on the Mac Mini to verify the functionality still worked as expected.