### PR TITLE
Fix Maven build-time warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,13 @@ Licensed under the MIT license. See License.txt in the project root. -->
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-ant</artifactId>
+            <version>2.4.5</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>com.ruleoftech</groupId>
@@ -521,7 +528,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy</artifactId>
       <version>2.4.5</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
             <configuration>
               <!-- http://stackoverflow.com/a/9339405 -->
               <properties>
-                <shaded_jar_checksum_file>${artifactId}-${version}.jar.sha256</shaded_jar_checksum_file>
+                <shaded_jar_checksum_file>${project.artifactId}-${project.version}.jar.sha256</shaded_jar_checksum_file>
               </properties>
               <scripts>
                 <script><![CDATA[


### PR DESCRIPTION
There were a couple of warnings during a Maven build that I took care of; see the individual commits for details.

Manual testing
--------------
Set my `JAVA_HOME` to JDK `1.6.0_20` on Windows and ran `mvn clean verify`.  There are no longer any warnings.

Mission accomplished!