### PR TITLE
Add support for proxy servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
     <dependency>
       <groupId>com.microsoft.alm</groupId>
       <artifactId>oauth2-useragent</artifactId>
-      <version>0.5.4</version>
+      <version>0.7.1</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -525,6 +525,7 @@ public class Program
         // i.e. !/usr/bin/jre\ 1.6/bin/java -Ddebug=false -jar /home/example/with\ spaces/gcm.jar
         sb.append("!").append(escapeSpaces(pathToJava));
         sb.append(" -Ddebug=").append(isDebug);
+        sb.append(" -Djava.net.useSystemProxies=true");
         sb.append(" -jar ").append(escapeSpaces(pathToJar));
         final String gcmCommandLine = sb.toString();
 

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -524,8 +524,8 @@ public class Program
         // escape spaces (if any) in paths to java and path to JAR
         // i.e. !/usr/bin/jre\ 1.6/bin/java -Ddebug=false -jar /home/example/with\ spaces/gcm.jar
         sb.append("!").append(escapeSpaces(pathToJava));
-        sb.append(" -Ddebug=").append(isDebug).append(" -jar ");
-        sb.append(escapeSpaces(pathToJar));
+        sb.append(" -Ddebug=").append(isDebug);
+        sb.append(" -jar ").append(escapeSpaces(pathToJar));
         final String gcmCommandLine = sb.toString();
 
         final String[] command =

--- a/src/test/java/com/microsoft/alm/gitcredentialmanager/ProgramTest.java
+++ b/src/test/java/com/microsoft/alm/gitcredentialmanager/ProgramTest.java
@@ -240,7 +240,7 @@ public class ProgramTest
                 Assert.assertEquals("--global", strings[2]);
                 Assert.assertEquals("--add", strings[3]);
                 Assert.assertEquals("credential.helper", strings[4]);
-                Assert.assertEquals("!/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.65-3.b17.fc22.x86_64/bin/java -Ddebug=false -jar /usr/bin/git-credential-manager-1.1.0.jar", strings[5]);
+                Assert.assertEquals("!/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.65-3.b17.fc22.x86_64/bin/java -Ddebug=false -Djava.net.useSystemProxies=true -jar /usr/bin/git-credential-manager-1.1.0.jar", strings[5]);
                 return process;
             }
         };
@@ -260,7 +260,7 @@ public class ProgramTest
                 Assert.assertEquals("--system", strings[2]);
                 Assert.assertEquals("--add", strings[3]);
                 Assert.assertEquals("credential.helper", strings[4]);
-                Assert.assertEquals("!/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands/java -Ddebug=true -jar /usr/local/bin/git-credential-manager-1.1.0.jar", strings[5]);
+                Assert.assertEquals("!/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands/java -Ddebug=true -Djava.net.useSystemProxies=true -jar /usr/local/bin/git-credential-manager-1.1.0.jar", strings[5]);
                 return process;
             }
         };

--- a/templates/Install.md
+++ b/templates/Install.md
@@ -109,7 +109,7 @@ Debug mode will turn on tracing and assertions, producing a lot of output to `st
     ```
     !java -Ddebug=false -Djava.net.useSystemProxies=true -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar
     ```
-2. Set a new value for the `credential.helper` configuration (essentially repeating the _manual configuration step_, being careful with quoting and spaces), changing the value of the `debug` property to `true` (or `false` to disable).
+2. Set a new value for the `credential.helper` configuration (essentially repeating the _manual configuration_ installation step, being careful with quoting and spaces), changing the value of the `debug` property to `true` (or `false` to disable).
 
 
 ## How to remove or uninstall

--- a/templates/Install.md
+++ b/templates/Install.md
@@ -112,6 +112,34 @@ Debug mode will turn on tracing and assertions, producing a lot of output to `st
 2. Set a new value for the `credential.helper` configuration (essentially repeating the _manual configuration_ installation step, being careful with quoting and spaces), changing the value of the `debug` property to `true` (or `false` to disable).
 
 
+## How to configure the proxy server
+If your network does not allow a direct connection to remote hosts, you can configure the GCM to perform requests through a web proxy.
+
+### Automatic configuration (recommended)
+If you are running Gnome 2.x or greater, you can configure the proxy settings using the GUI and the GCM will use those settings thanks to a JVM feature that's activated by setting the `java.net.useSystemProxies` system property to `true` (this is now done automatically when running the GCM in `install` mode).
+
+### Manual configuration
+
+If it's not possible to use the automatic proxy server configuration, you must set the appropriate [networking properties](http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html). Aside from SOCKS proxy servers, which can have their credentials specified through specific properties, authenticated proxy servers are currently not supported.
+
+1. Retrieve the value of the `credential.helper` configuration:
+
+    ```
+    git config --global --get credential.helper ${project.artifactId}
+    ```
+    ...it should look like this:
+
+    ```
+    !java -Ddebug=false -Djava.net.useSystemProxies=true -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar
+    ```
+2. Set a new value for the `credential.helper` configuration (essentially repeating the _manual configuration_ installation step, being careful with quoting and spaces), adding the appropriate properties.  For example, if you have a proxy server that can do HTTP and HTTPS, running on the host `192.168.0.117`, listening on port `8123`, then you would run the following (notice there's a pair of properties for http and one for https).
+
+
+    ```
+    git config --global credential.helper '!java -Ddebug=false -Dhttp.proxyHost=192.168.0.117 -Dhttp.proxyPort=8123 -Dhttps.proxyHost=192.168.0.117 -Dhttps.proxyPort=8123 -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar'
+    ```
+
+
 ## How to remove or uninstall
 We are sad to see you go!  Please give us some feedback on how we could do better next time.
 

--- a/templates/Install.md
+++ b/templates/Install.md
@@ -82,7 +82,7 @@ Download [${project.artifactId}-${project.version}.jar](https://github.com/Micro
 1. Configure the `credential.helper` setting to launch Java with the absolute path to the JAR (make sure you surround the whole value with 'single quotes'):
 
     ```
-    git config --global credential.helper '!java -Ddebug=false -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar'
+    git config --global credential.helper '!java -Ddebug=false -Djava.net.useSystemProxies=true -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar'
     ```
 
 
@@ -107,7 +107,7 @@ Debug mode will turn on tracing and assertions, producing a lot of output to `st
     ...it should look like this:
 
     ```
-    !java -Ddebug=false -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar
+    !java -Ddebug=false -Djava.net.useSystemProxies=true -jar /home/example/${project.artifactId}/${project.artifactId}-${project.version}.jar
     ```
 2. Set a new value for the `credential.helper` configuration (essentially repeating the _manual configuration step_, being careful with quoting and spaces), changing the value of the `debug` property to `true` (or `false` to disable).
 


### PR DESCRIPTION
After upgrading oauth2-useragent to version 0.7.1, what was missing was setting the `java.net.useSystemProxies` system property when installing the GCM.

The installation documentation was likewise updated.  See the new [How to configure the proxy server](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/blob/support_proxy_servers/templates/Install.md#how-to-configure-the-proxy-server) section.

The manual testing was already done as part of microsoft/oauth2-useragent#17.