### PR TITLE
Remove support for Java 7 on Mac OS X 10.11 and up

### DIFF
--- a/templates/Install.md
+++ b/templates/Install.md
@@ -6,9 +6,11 @@ This document explains how to obtain the Git Credential Manager for Mac and Linu
 
 Great care was taken to avoid using any features of Java that would impact compatibility with Java 6.  Unfortunately, at this time, only the JavaFX-based browser is available, which excludes Java 6.  If you find a compatibility issue, please report it and provide as many details about your platform as necessary to reproduce the problem.
 
-1. Mac OS X version 10.9.5 and up OR a GNU/Linux distribution with a desktop environment.
-2. Oracle Java 7 Update 6 and up, Oracle Java 8, or OpenJDK with OpenJFX.
-3. Git version 1.9 and up.
+| Operating System | Minimum Java version | Minimum Git version | Notes |
+|------------------|----------------------|---------------------|-------|
+| Mac OS X 10.9.5 - 10.10 | Oracle Java 7 Update 6 | 1.9 |  |
+| Mac OS X 10.11 and up | Oracle Java 8 | 1.9 | It looks like [Java FX from Oracle Java 7 is broken on Mac OS X 10.11](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8143907). |
+| GNU/Linux | Oracle Java 8 <br /> - or - <br /> OpenJDK 8 [with OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Building+OpenJFX) | 1.9 | You need a desktop environment, such as Gnome or KDE. |
 
 
 ## How to install

--- a/templates/git-credential-manager.rb
+++ b/templates/git-credential-manager.rb
@@ -6,7 +6,8 @@ class GitCredentialManager < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+" if MacOS.version >= :el_capitan
+  depends_on :java => "1.7+" unless MacOS.version >= :el_capitan
 
   def install
     libexec.install "git-credential-manager-#{version}.jar"


### PR DESCRIPTION
As a follow-on to Microsoft/oauth2-useragent#19, update documentation and Homebrew formula to identify Java 8 when running on Mac OS X 10.11 (El Capitan) or greater.

Manual testing
==============

1. On a Mac running OS X 10.10.5 (Yosemite):
    1. [Install Homebrew](http://brew.sh/).
    2. Temporarily inject the changes to `Library/Formula/git-credential-manager.rb` in the Git repo that's cloned as part of installing Homebrew. 
    3. Temporarily uninstall Java.
    4. Attempt to install the `git-credential-manager` formula:

        ```
        $ brew install git-credential-manager
        git-credential-manager: Java 1.7+ is required to install this formula.
        You can install with Homebrew Cask:
        brew install Caskroom/cask/java

        You can download from:
        http://www.oracle.com/technetwork/java/javase/downloads/index.html
        Error: An unsatisfied requirement failed this build.
        ```
    5. Install JDK 7u80.
    6. Install the `git-credential-manager` via Homebrew:

        ```
        brew install git-credential-manager
        ```
    7. Install the GCM in Git:

        ```
        git-credential-manager install
        ```
    8. Confirm the GCM was configured in `~/.gitconfig`.
    9. Clone a Git repo hosted in VSTS, clearing any previously-saved credentials if necessary to force the OAuth 2.0 auth flow with the web browser pop-up.
2. On a Mac running OS X 10.11 (El Capitan):
    1. [Install Homebrew](http://brew.sh/).
    2. Temporarily inject the changes to `Library/Formula/git-credential-manager.rb` in the Git repo that's cloned as part of installing Homebrew. 
    3. Temporarily uninstall Java.
    4. Attempt to install the `git-credential-manager` formula:

        ```
        $ brew install git-credential-manager
        git-credential-manager: Java 1.8+ is required to install this formula.
        You can install with Homebrew Cask:
        brew install Caskroom/cask/java

        You can download from:
        http://www.oracle.com/technetwork/java/javase/downloads/index.html
        Error: An unsatisfied requirement failed this build.
        ```
    5. Install JDK 8u73.
    6. Install the `git-credential-manager` via Homebrew:

        ```
        brew install git-credential-manager
        ```
    7. Install the GCM in Git:

        ```
        git-credential-manager install
        ```
    8. Confirm the GCM was configured in `~/.gitconfig`.
    9. Clone a Git repo hosted in VSTS, clearing any previously-saved credentials if necessary to force the OAuth 2.0 auth flow with the web browser pop-up.

Mission accomplished!
