### PR TITLE
Fail faster and more explicitly

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
@@ -130,8 +130,7 @@ class AzureAuthority implements IAzureAuthority
         }
         catch (final IOException e)
         {
-            // TODO: 449248: silently catching the exception here seems horribly wrong
-            Trace.writeLine("   token acquisition failed.");
+            throw new Error("   token acquisition failed.", e);
         }
         return tokens;
     }
@@ -182,8 +181,9 @@ class AzureAuthority implements IAzureAuthority
                 authorizationCode = null;
             }
         }
-        catch (final AuthorizationException ignored)
+        catch (final AuthorizationException e)
         {
+            throw new Error(e);
         }
         return authorizationCode;
     }

--- a/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
@@ -285,8 +285,9 @@ public abstract class BaseVsoAuthentication extends BaseAuthentication
                 return !StringHelper.isNullOrWhiteSpace(tenant)
                         && Guid.tryParse(tenant, tenantId);
             }
-            catch (final IOException ignored)
+            catch (final IOException e)
             {
+                throw new Error(e);
             }
         }
 

--- a/src/main/java/com/microsoft/alm/authentication/Token.java
+++ b/src/main/java/com/microsoft/alm/authentication/Token.java
@@ -272,7 +272,7 @@ public class Token extends Secret
         }
         catch (final Throwable throwable)
         {
-            Trace.writeLine("   token deserialization error");
+            throw new Error("   token deserialization error", throwable);
         }
 
         return tokenReference.get() != null;
@@ -299,9 +299,9 @@ public class Token extends Secret
             bytes.put(utf8bytes);
             byteReference.set(bytes.array());
         }
-        catch(final Throwable t)
+        catch (final Throwable t)
         {
-            Trace.writeLine("   token serialization error");
+            throw new Error("   token serialization error", t);
         }
 
         return byteReference.get() != null;

--- a/src/main/java/com/microsoft/alm/authentication/VsoAzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoAzureAuthority.java
@@ -85,7 +85,7 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
                 }
             }
         }
-        catch (IOException e)
+        catch (final IOException e)
         {
             throw new Error(e);
         }
@@ -112,7 +112,7 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
         }
         catch (final IOException e)
         {
-            Trace.writeLine("   server returned " + e.getMessage());
+            throw new Error(e);
         }
 
         final AtomicReference<UUID> instanceId = new AtomicReference<UUID>();
@@ -156,16 +156,12 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
         }
         catch (final IOException e)
         {
-            Trace.writeLine("   server returned: " + e.getMessage());
+            throw new Error(e);
         }
-        catch(final Throwable ignored)
+        catch (final Throwable ignored)
         {
-            Trace.writeLine("   unexpected error");
+            throw new Error("   unexpected error", ignored);
         }
-
-        Trace.writeLine("   credential validation failed");
-        return false;
-
     }
 
     /**

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/InsecureStore.java
@@ -81,7 +81,7 @@ public class InsecureStore implements ISecureStore
                     this.Credentials.putAll(clone.Credentials);
                 }
             }
-            catch (FileNotFoundException e)
+            catch (final FileNotFoundException e)
             {
                 Trace.writeLine("backingFile '" + backingFile.getAbsolutePath() + "' did not exist.");
             }

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -485,11 +485,11 @@ public class Program
                 uninstall(processFactory);
                 configureGit(processFactory, configLocation);
             }
-            catch (IOException e)
+            catch (final IOException e)
             {
                 throw new Error(e);
             }
-            catch (InterruptedException e)
+            catch (final InterruptedException e)
             {
                 throw new Error(e);
             }
@@ -574,11 +574,11 @@ public class Program
                 unconfigureGit(processFactory, configLocation);
             }
         }
-        catch (IOException e)
+        catch (final IOException e)
         {
             throw new Error(e);
         }
-        catch (InterruptedException e)
+        catch (final InterruptedException e)
         {
             throw new Error(e);
         }

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -103,19 +103,19 @@ public class Program
 
             program.innerMain(args);
         }
-        catch (final Exception exception)
+        catch (final Throwable throwable)
         {
             if (Debug.IsDebug)
             {
                 System.err.println("Fatal error encountered.  Details:");
-                exception.printStackTrace(System.err);
+                throwable.printStackTrace(System.err);
             }
             else
             {
-                System.err.println("Fatal: " + exception.getClass().getName() + " encountered.  Details:");
-                System.err.println(exception.getMessage());
+                System.err.println("Fatal: " + throwable.getClass().getName() + " encountered.  Details:");
+                System.err.println(throwable.getMessage());
             }
-            logEvent(exception.getMessage(), "EventLogEntryType.Error");
+            logEvent(throwable.getMessage(), "EventLogEntryType.Error");
             // notice the lack of a new line; Git needs it that way
             System.out.print(AbortAuthenticationProcessResponse);
         }


### PR DESCRIPTION
## Summary

A number of `catch` blocks were simply tracing or silently swallowing errors.  I reviewed and decided to re-throw in many of the cases, because it would allow an error condition to fail the program faster and with a more obvious cause.

## Manual testing

On a Fedora 22 VM:

1. Disable direct access to the internet such that a proxy server must be used. 
2. Configure the proxy server by modifying the `credential.helper` value in `.gitconfig`:
    1. Remove `-Djava.net.useSystemProxies=true`
    2. Add `-Dhttps.proxyHost=192.168.0.117`
    3. Add `-Dhttps.proxyPort=8123`
3. Rename `~/git-credential-manager/insecureStore.xml` to  `~/git-credential-manager/insecureStore.xml.old`
4. Attempt a `git fetch` in a clone of a Git repository hosted in VSTS.
    1. Close the browser window that pops up.
    2. The GCM4ML terminates (the error details contain the string "cancelled") and asks Git to stop prompting for credentials, returning to the prompt.
5. Temporarily break the proxy server configuration by setting `https.proxyPort` to the wrong port.
6. Attempt a `git fetch` in a clone of a Git repository hosted in VSTS.
    1. Execution pauses at `detected visualstudio.com, checking AAD vs MSA` until a timeout is triggered.
    2. The GCM4ML terminates (the error details contain the string "No route to host") and asks Git to stop prompting for credentials, returning to the prompt.
 