### PR TITLE
Wire up the new Device Flow feature

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
@@ -217,7 +217,7 @@ class AzureAuthority implements IAzureAuthority
         }
         catch (final AuthorizationException e)
         {
-            throw new Error(e);
+            Trace.writeLine("Authorization code could not be obtained: ", e);
         }
         return authorizationCode;
     }

--- a/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
@@ -150,6 +150,11 @@ class AzureAuthority implements IAzureAuthority
         throw new NotImplementedException(449285);
     }
 
+    public TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Action<DeviceFlowResponse> callback)
+    {
+        throw new NotImplementedException(560199);
+    }
+
     /**
      * Acquires an access token from the authority using a previously acquired refresh token.
      *

--- a/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
@@ -51,10 +51,10 @@ class AzureAuthority implements IAzureAuthority
      */
     public AzureAuthority(final String authorityHostUrl)
     {
-        this(authorityHostUrl, new UserAgentImpl());
+        this(authorityHostUrl, new UserAgentImpl(), new AzureDeviceFlow());
     }
 
-    AzureAuthority(final String authorityHostUrl, final UserAgent userAgent)
+    AzureAuthority(final String authorityHostUrl, final UserAgent userAgent, final AzureDeviceFlow azureDeviceFlow)
     {
         Debug.Assert(UriHelper.isWellFormedUriString(authorityHostUrl), "The authorityHostUrl parameter is invalid.");
         Debug.Assert(userAgent != null, "The userAgent parameter is null.");
@@ -62,10 +62,12 @@ class AzureAuthority implements IAzureAuthority
         this.authorityHostUrl = authorityHostUrl;
         _adalTokenCache = /* TODO: 449201: consider new InsecureStore("adalTokenCache.xml");*/null;
         _userAgent = userAgent;
+        _azureDeviceFlow = azureDeviceFlow;
     }
 
     private final VsoAdalTokenCache _adalTokenCache;
     private final UserAgent _userAgent;
+    private final AzureDeviceFlow _azureDeviceFlow;
 
     protected String authorityHostUrl;
     /**

--- a/src/main/java/com/microsoft/alm/authentication/IAzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/IAzureAuthority.java
@@ -3,11 +3,14 @@
 
 package com.microsoft.alm.authentication;
 
+import com.microsoft.alm.helpers.Action;
+
 import java.net.URI;
 
 interface IAzureAuthority
 {
     TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final URI redirectUri, final String queryParameters);
     TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Credential credentials);
+    TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Action<DeviceFlowResponse> callback);
     TokenPair acquireTokenByRefreshToken(final URI targetUri, final String clientId, final String resource, final Token refreshToken);
 }

--- a/src/main/java/com/microsoft/alm/authentication/IVsoAadAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/IVsoAadAuthentication.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.alm.authentication;
 
+import com.microsoft.alm.helpers.Action;
+
 import java.net.URI;
 
 public interface IVsoAadAuthentication extends IAuthentication
@@ -10,6 +12,7 @@ public interface IVsoAadAuthentication extends IAuthentication
     boolean interactiveLogon(final URI targetUri, final boolean requestCompactToken);
     boolean noninteractiveLogonWithCredentials(final URI targetUri, final Credential credentials, final boolean requestCompactToken);
     boolean noninteractiveLogon(final URI targetUri, final boolean requestCompactToken);
+    boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback);
     boolean refreshCredentials(final URI targetUri, final boolean requireCompactToken);
     boolean validateCredentials(final URI targetUri, final Credential credentials);
 }

--- a/src/main/java/com/microsoft/alm/authentication/IVsoMsaAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/IVsoMsaAuthentication.java
@@ -3,11 +3,14 @@
 
 package com.microsoft.alm.authentication;
 
+import com.microsoft.alm.helpers.Action;
+
 import java.net.URI;
 
 public interface IVsoMsaAuthentication extends IAuthentication
 {
     boolean interactiveLogon(final URI targetUri, boolean requestCompactToken);
+    boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback);
     boolean refreshCredentials(final URI targetUri, final boolean requireCompactToken);
     boolean validateCredentials(final URI targetUri, final Credential credentials);
 }

--- a/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
@@ -145,7 +145,22 @@ public final class VsoAadAuthentication extends BaseVsoAuthentication implements
 
     public boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback)
     {
-        throw new NotImplementedException(560199);
+        BaseSecureStore.validateTargetUri(targetUri);
+
+        Trace.writeLine("VsoAadAuthentication::deviceLogon");
+
+        TokenPair tokens;
+        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, callback)) != null)
+        {
+            Trace.writeLine("   token successfully acquired.");
+
+            this.storeRefreshToken(targetUri, tokens.RefreshToken);
+
+            return this.generatePersonalAccessToken(targetUri, tokens.AccessToken, requestCompactToken);
+        }
+
+        Trace.writeLine("   failed to acquire token.");
+        return false;
     }
 
     /**

--- a/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.authentication;
 
+import com.microsoft.alm.helpers.Action;
 import com.microsoft.alm.helpers.Guid;
 import com.microsoft.alm.helpers.NotImplementedException;
 import com.microsoft.alm.helpers.Trace;
@@ -140,6 +141,11 @@ public final class VsoAadAuthentication extends BaseVsoAuthentication implements
     public boolean noninteractiveLogon(final URI targetUri, final boolean requestCompactToken)
     {
         throw new NotImplementedException(449285);
+    }
+
+    public boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback)
+    {
+        throw new NotImplementedException(560199);
     }
 
     /**

--- a/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.alm.authentication;
 
+import com.microsoft.alm.helpers.Action;
+import com.microsoft.alm.helpers.NotImplementedException;
 import com.microsoft.alm.helpers.Trace;
 
 import java.net.URI;
@@ -69,6 +71,12 @@ public final class VsoMsaAuthentication extends BaseVsoAuthentication implements
         Trace.writeLine("   failed to acquire token.");
         return false;
     }
+
+    public boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback)
+    {
+        throw new NotImplementedException(560199);
+    }
+
     /**
      * Sets credentials for future use with this authentication object.
      * Not supported.

--- a/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
@@ -4,7 +4,6 @@
 package com.microsoft.alm.authentication;
 
 import com.microsoft.alm.helpers.Action;
-import com.microsoft.alm.helpers.NotImplementedException;
 import com.microsoft.alm.helpers.Trace;
 
 import java.net.URI;
@@ -74,7 +73,22 @@ public final class VsoMsaAuthentication extends BaseVsoAuthentication implements
 
     public boolean deviceLogon(final URI targetUri, final boolean requestCompactToken, final Action<DeviceFlowResponse> callback)
     {
-        throw new NotImplementedException(560199);
+        BaseSecureStore.validateTargetUri(targetUri);
+
+        Trace.writeLine("VsoMsaAuthentication::deviceLogon");
+
+        TokenPair tokens;
+        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, callback)) != null)
+        {
+            Trace.writeLine("   token successfully acquired.");
+
+            this.storeRefreshToken(targetUri, tokens.RefreshToken);
+
+            return this.generatePersonalAccessToken(targetUri, tokens.AccessToken, requestCompactToken);
+        }
+
+        Trace.writeLine("   failed to acquire token.");
+        return false;
     }
 
     /**

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -332,6 +332,11 @@ public class Program
                         && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
                         && (!operationArguments.ValidateCredentials
                             || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                    || (operationArguments.Interactivity != Interactivity.Never
+                        && aadAuth.deviceLogon(operationArguments.TargetUri, true, deviceFlowCallback)
+                        && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
                 )
                 {
                     Trace.writeLine("   credentials found");

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -296,25 +296,27 @@ public class Program
 
                 // attempt to get cached creds -> refresh creds -> non-interactive logon -> interactive logon
                 // note that AAD "credentials" are always scoped access tokens
-                if (((operationArguments.Interactivity != Interactivity.Always
+                if (
+                    (operationArguments.Interactivity != Interactivity.Always
                         && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
                         && (!operationArguments.ValidateCredentials
                             || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
-                        || (operationArguments.Interactivity != Interactivity.Always
-                            && aadAuth.refreshCredentials(operationArguments.TargetUri, true)
-                            && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
-                            && (!operationArguments.ValidateCredentials
-                                || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                    || (operationArguments.Interactivity != Interactivity.Always
+                        && aadAuth.refreshCredentials(operationArguments.TargetUri, true)
+                        && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
 //                        || (operationArguments.Interactivity != Interactivity.Always
 //                            && aadAuth.noninteractiveLogon(operationArguments.TargetUri, true)
 //                            && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
 //                            && (!operationArguments.ValidateCredentials
 //                                || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
-                        || (operationArguments.Interactivity != Interactivity.Never
-                            && aadAuth.interactiveLogon(operationArguments.TargetUri, true))
-                            && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
-                            && (!operationArguments.ValidateCredentials
-                                || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get()))))
+                    || (operationArguments.Interactivity != Interactivity.Never
+                        && aadAuth.interactiveLogon(operationArguments.TargetUri, true)
+                        && aadAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || aadAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                )
                 {
                     Trace.writeLine("   credentials found");
                     operationArguments.setCredentials(credentials.get());
@@ -334,20 +336,22 @@ public class Program
 
                 // attempt to get cached creds -> refresh creds -> interactive logon
                 // note that MSA "credentials" are always scoped access tokens
-                if (((operationArguments.Interactivity != Interactivity.Always
+                if (
+                    (operationArguments.Interactivity != Interactivity.Always
                         && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
                         && (!operationArguments.ValidateCredentials
                             || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
-                        || (operationArguments.Interactivity != Interactivity.Always
-                            && msaAuth.refreshCredentials(operationArguments.TargetUri, true)
-                            && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
-                            && (!operationArguments.ValidateCredentials
-                                || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
-                        || (operationArguments.Interactivity != Interactivity.Never
-                            && msaAuth.interactiveLogon(operationArguments.TargetUri, true))
-                            && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
-                            && (!operationArguments.ValidateCredentials
-                                || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get()))))
+                    || (operationArguments.Interactivity != Interactivity.Always
+                        && msaAuth.refreshCredentials(operationArguments.TargetUri, true)
+                        && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                    || (operationArguments.Interactivity != Interactivity.Never
+                        && msaAuth.interactiveLogon(operationArguments.TargetUri, true)
+                        && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                )
                 {
                     Trace.writeLine("   credentials found");
                     operationArguments.setCredentials(credentials.get());

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -367,6 +367,11 @@ public class Program
                         && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
                         && (!operationArguments.ValidateCredentials
                             || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
+                    || (operationArguments.Interactivity != Interactivity.Never
+                        && msaAuth.deviceLogon(operationArguments.TargetUri, true, deviceFlowCallback)
+                        && msaAuth.getCredentials(operationArguments.TargetUri, credentials)
+                        && (!operationArguments.ValidateCredentials
+                            || msaAuth.validateCredentials(operationArguments.TargetUri, credentials.get())))
                 )
                 {
                     Trace.writeLine("   credentials found");

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -287,10 +287,10 @@ public class Program
         final AtomicReference<OperationArguments> operationArgumentsRef = new AtomicReference<OperationArguments>();
         final AtomicReference<IAuthentication> authenticationRef = new AtomicReference<IAuthentication>();
         initialize("get", operationArgumentsRef, authenticationRef);
-        final String result = get(operationArgumentsRef.get(), authenticationRef.get());
+        final String result = get(operationArgumentsRef.get(), authenticationRef.get(), DEVICE_FLOW_CALLBACK);
         standardOut.print(result);
     }
-    public static String get(final OperationArguments operationArguments, final IAuthentication authentication)
+    public static String get(final OperationArguments operationArguments, final IAuthentication authentication, final Action<DeviceFlowResponse> deviceFlowCallback)
     {
         final String AuthFailureMessage = "Logon failed, aborting authentication process.";
 

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -7,6 +7,7 @@ import com.microsoft.alm.authentication.BaseVsoAuthentication;
 import com.microsoft.alm.authentication.BasicAuthentication;
 import com.microsoft.alm.authentication.Configuration;
 import com.microsoft.alm.authentication.Credential;
+import com.microsoft.alm.authentication.DeviceFlowResponse;
 import com.microsoft.alm.authentication.IAuthentication;
 import com.microsoft.alm.authentication.ISecureStore;
 import com.microsoft.alm.authentication.ITokenStore;
@@ -18,6 +19,7 @@ import com.microsoft.alm.authentication.VsoAadAuthentication;
 import com.microsoft.alm.authentication.VsoMsaAuthentication;
 import com.microsoft.alm.authentication.VsoTokenScope;
 import com.microsoft.alm.authentication.Where;
+import com.microsoft.alm.helpers.Action;
 import com.microsoft.alm.helpers.Debug;
 import com.microsoft.alm.helpers.Environment;
 import com.microsoft.alm.helpers.Func;
@@ -70,6 +72,20 @@ public class Program
     private final InputStream standardIn;
     private final PrintStream standardOut;
     private final IComponentFactory componentFactory;
+    private static final Action<DeviceFlowResponse> DEVICE_FLOW_CALLBACK = new Action<DeviceFlowResponse>()
+    {
+        @Override public void call(final DeviceFlowResponse deviceFlowResponse)
+        {
+            System.err.println("------------------------------------");
+            System.err.println("OAuth 2.0 Device Flow authentication");
+            System.err.println("------------------------------------");
+            System.err.println("To complete the authentication process, please open a web browser and visit the following URI:");
+            System.err.println(deviceFlowResponse.getVerificationUri());
+            System.err.println("When prompted, enter the following code:");
+            System.err.println(deviceFlowResponse.getUserCode());
+            System.err.println("Once authenticated and authorized, execution will continue.");
+        }
+    };
 
     // http://stackoverflow.com/a/6773868/
     static String getVersion()

--- a/src/main/java/com/microsoft/alm/helpers/Trace.java
+++ b/src/main/java/com/microsoft/alm/helpers/Trace.java
@@ -35,4 +35,9 @@ public class Trace
             listener.println(message);
         }
     }
+
+    public static void writeLine(final String message, final Throwable throwable)
+    {
+        writeLine(message + throwable.toString());
+    }
 }


### PR DESCRIPTION
OAuth 2.0 Device Flow is now wired up and will be attempted as a last resort.

Manual testing
--------------

1. Add a Git remote to a clone of this repo pointing to a VSTS account that uses **Microsoft Accounts (MSA)**.  Let's call the remote `msarepo`.
2. Run `git push msarepo`.
3. When the JavaFX browser opens, immediately close the window.  This used to completely abort the GCM4ML; now we get something like this:

    ```
------------------------------------
OAuth 2.0 Device Flow authentication
------------------------------------
To complete the authentication process, please open a web browser and visit the following URI:
https://aka.ms/devicelogin
When prompted, enter the following code:
E3P3CAVVR
Once authenticated and authorized, execution will continue.
    ```
4. Follow the instructions to authenticate.
5. The push succeeds.
1. Add a Git remote to a clone of this repo pointing to a VSTS account that uses **Azure Active Directory (AAD)**.  Let's call the remote `aadrepo`.
2. Run `git push aadrepo`.
3. When the JavaFX browser opens, immediately close the window.  This used to completely abort the GCM4ML; now we get something like this:

    ```
------------------------------------
OAuth 2.0 Device Flow authentication
------------------------------------
To complete the authentication process, please open a web browser and visit the following URI:
https://aka.ms/devicelogin
When prompted, enter the following code:
EYCSHYPEC
Once authenticated and authorized, execution will continue.
    ```
4. Follow the instructions to authenticate.
5. The push succeeds.

Mission accomplished!