### PR TITLE
Reduce JavaFX failure output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
     <dependency>
       <groupId>com.microsoft.alm</groupId>
       <artifactId>oauth2-useragent</artifactId>
-      <version>0.8.1</version>
+      <version>0.9.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Manual Testing
--------------

These steps were performed on my Windows 10 workstation:

1. Temporarily disable the insecure store file to force authentication.  I did that by appending `.old` to `%LOCALAPPDATA%/git-credential-manager/insecureStore.xml`.
1. Create a file called input.txt containing the following:

    ```
    protocol=https
    host=mseng.visualstudio.com
    ```

1. Launch the GCM4ML in `get` mode, with stdin coming from `input.txt` and using a JRE that doesn't support JavaFX, such as Java 6.  This is what my command-line looked like:

    ```
    /cygdrive/e/Software/Java/jdk1.6.0_20/bin/java -Ddebug=true -jar target/git-credential-manager-1.7.2-SNAPSHOT.jar get < input.txt
    ```
    
1. Before the changes from this pull request, we would have gotten the following _debug_ output:

    ```
    VsoAadAuthentication::interactiveLogon
    AzureAuthority::acquireToken
    Authorization code could not be obtained: java.lang.IllegalStateException: I don't support your platform yet.
    Unmet requirements for the 'JavaFx' provider:
     - Oracle Java SE 7 update 6 or higher, Oracle Java SE 8, OR OpenJDK 8.
     - JavaFX or OpenJFX runtime JAR.

    Please send details about your operating system version, Java version, 32- vs. 64-bit, etc.
    The following System Properties and Environment Variables would be very useful.
    # --- BEGIN SYSTEM PROPERTIES ---
    (...snip...)
    # ---- END SYSTEM PROPERTIES ----

    # --- BEGIN ENVIRONMENT VARIABLES ---
    (...snip...)
    # ---- END ENVIRONMENT VARIABLES ----

       token acquisition failed.
       interactive logon failed
    VsoAadAuthentication::deviceLogon
    AzureAuthority::acquireToken
    ```

    ...and now we get the following _debug_ output:

    ```
    VsoAadAuthentication::interactiveLogon
    AzureAuthority::acquireToken

    Unmet requirements for the 'JavaFx' provider:
     - Oracle Java SE 7 update 6 or higher, Oracle Java SE 8, OR OpenJDK 8.
     - JavaFX or OpenJFX runtime JAR.

       token acquisition failed.
       interactive logon failed
    VsoAadAuthentication::deviceLogon
    AzureAuthority::acquireToken
    ```

1. Re-enable the insecure store file.

Mission accomplished!