### PR TITLE
Make hardcoded credential-osxkeychain workaround opt-out instead of opt-in

### DIFF
--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/OperationArguments.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/OperationArguments.java
@@ -23,7 +23,7 @@ final class OperationArguments
         this.Interactivity = com.microsoft.alm.gitcredentialmanager.Interactivity.Auto;
         this.ValidateCredentials = true;
         this.WriteLog = false;
-        this.EraseOsxKeyChain = false;
+        this.EraseOsxKeyChain = true;
 
         String protocol = null;
         String host = null;

--- a/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
+++ b/src/main/java/com/microsoft/alm/gitcredentialmanager/Program.java
@@ -221,7 +221,7 @@ public class Program
         standardOut.println("                      The workaround is to preemptively erase from osxkeychain");
         standardOut.println("                      any Git credentials that can be refreshed or re-acquired");
         standardOut.println("                      by this credential helper.");
-        standardOut.println("                      Defaults to FALSE. Ignored by Basic authority.");
+        standardOut.println("                      Defaults to TRUE. Ignored by Basic authority.");
         standardOut.println("                      Does nothing if Apple Git on Mac OS X isn't detected.");
         standardOut.println();
         standardOut.println("      `git config --global credential.microsoft.visualstudio.com.eraseosxkeychain false`");


### PR DESCRIPTION
Also expand to any version of Git that makes `git-credential-osxkeychain` available, not just "Apple Git".  This covers the [Git OSX Installer](https://git-scm.com/download/mac) which has a more "traditional" version string, yet behaves the same with respect to hardcoding the osxkeychain credential helper first.

Manual testing
--------------

For each of the following distributions of Git:

1. Apple
2. Homebrew
3. OSX Installer

...performed a `git fetch` against a _Visual Studio Team Services_ Git repository and kept a close eye on the Keychain application.  For **Apple** and **OSX Installer**, an entry would briefly appear in the Keychain before being deleted by the GCM4ML.  In the **Homebrew** case, no entry appeared.  In all cases, the fetch succeeded.

Mission accomplished!