### PR TITLE
Update the Azure Active Directory client ID

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureAuthority.java
@@ -156,7 +156,7 @@ class AzureAuthority implements IAzureAuthority
         throw new NotImplementedException(449285);
     }
 
-    public TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Action<DeviceFlowResponse> callback)
+    public TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final URI redirectUri, final Action<DeviceFlowResponse> callback)
     {
         Debug.Assert(targetUri != null && targetUri.isAbsolute(), "The targetUri parameter is null or invalid");
         Debug.Assert(!StringHelper.isNullOrWhiteSpace(clientId), "The clientId parameter is null or empty");
@@ -166,6 +166,7 @@ class AzureAuthority implements IAzureAuthority
         Trace.writeLine("AzureAuthority::acquireToken");
 
         _azureDeviceFlow.setResource(resource);
+        _azureDeviceFlow.setRedirectUri(redirectUri);
         final StringBuilder sb = new StringBuilder(authorityHostUrl);
         sb.append("/oauth2/devicecode");
         final URI deviceEndpoint = URI.create(sb.toString());

--- a/src/main/java/com/microsoft/alm/authentication/AzureDeviceFlow.java
+++ b/src/main/java/com/microsoft/alm/authentication/AzureDeviceFlow.java
@@ -5,9 +5,12 @@ package com.microsoft.alm.authentication;
 
 import com.microsoft.alm.helpers.QueryString;
 
+import java.net.URI;
+
 public class AzureDeviceFlow extends DeviceFlowImpl
 {
     private String resource;
+    private URI redirectUri;
 
     public String getResource()
     {
@@ -19,12 +22,27 @@ public class AzureDeviceFlow extends DeviceFlowImpl
         this.resource = resource;
     }
 
+    public URI getRedirectUri()
+    {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(final URI redirectUri)
+    {
+        this.redirectUri = redirectUri;
+    }
+
     @Override
     protected void contributeAuthorizationRequestParameters(final QueryString bodyParameters)
     {
         if (resource != null)
         {
             bodyParameters.put("resource", resource);
+        }
+
+        if (redirectUri != null)
+        {
+            bodyParameters.put(OAuthParameter.REDIRECT_URI, redirectUri.toString());
         }
     }
 

--- a/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/BaseVsoAuthentication.java
@@ -22,9 +22,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class BaseVsoAuthentication extends BaseAuthentication
 {
     public static final String DefaultResource = "499b84ac-1321-427f-aa17-267ca6975798";
-    // TODO: 449327: request a client_id and redirect URI, these are MSOpenTech's
-    public static final String DefaultClientId = "61d65f5a-6e3b-468b-af73-a033f5098c5c";
-    public static final URI RedirectUri = URI.create("https://msopentech.com");
+    public static final String DefaultClientId = "97877f11-0fc6-4aee-b1ff-febb0519dd00";
+    public static final URI RedirectUri = URI.create("https://java.visualstudio.com");
 
     protected static final String AdalRefreshPrefix = "ada";
 

--- a/src/main/java/com/microsoft/alm/authentication/IAzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/IAzureAuthority.java
@@ -11,6 +11,6 @@ interface IAzureAuthority
 {
     TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final URI redirectUri, final String queryParameters);
     TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Credential credentials);
-    TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final Action<DeviceFlowResponse> callback);
+    TokenPair acquireToken(final URI targetUri, final String clientId, final String resource, final URI redirectUri, final Action<DeviceFlowResponse> callback);
     TokenPair acquireTokenByRefreshToken(final URI targetUri, final String clientId, final String resource, final Token refreshToken);
 }

--- a/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoAadAuthentication.java
@@ -89,7 +89,7 @@ public final class VsoAadAuthentication extends BaseVsoAuthentication implements
         Trace.writeLine("VsoAadAuthentication::interactiveLogon");
 
         TokenPair tokens;
-        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, RedirectUri, null)) != null)
+        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, RedirectUri, (String) null)) != null)
         {
             Trace.writeLine("   token acquisition succeeded.");
 
@@ -150,7 +150,7 @@ public final class VsoAadAuthentication extends BaseVsoAuthentication implements
         Trace.writeLine("VsoAadAuthentication::deviceLogon");
 
         TokenPair tokens;
-        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, callback)) != null)
+        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, RedirectUri, callback)) != null)
         {
             Trace.writeLine("   token successfully acquired.");
 

--- a/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoMsaAuthentication.java
@@ -78,7 +78,7 @@ public final class VsoMsaAuthentication extends BaseVsoAuthentication implements
         Trace.writeLine("VsoMsaAuthentication::deviceLogon");
 
         TokenPair tokens;
-        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, callback)) != null)
+        if ((tokens = this.VsoAuthority.acquireToken(targetUri, this.ClientId, this.Resource, RedirectUri, callback)) != null)
         {
             Trace.writeLine("   token successfully acquired.");
 

--- a/src/test/java/com/microsoft/alm/authentication/AzureAuthorityTest.java
+++ b/src/test/java/com/microsoft/alm/authentication/AzureAuthorityTest.java
@@ -20,6 +20,7 @@ public class AzureAuthorityTest
     static final String TEST_CLIENT_ID = "d30feefe-9ee4-4b00-ac77-08dbd1199811";
     static final String TEST_DEVICE_CODE = "03d5f4b1-c8ab-4ce2-85c0-158d2075ff5f";
     static final String TEST_USER_CODE = "DEADBEEF";
+    static final URI TEST_REDIRECT_URI = URI.create("https://terminus.example.com");
     static final int TEST_EXPIRATION = 600;
     static final int TEST_INTERVAL = 5;
     static final String TEST_ACCESS_TOKEN = "bacf8b5f-63f2-4998-9170-d32cf7db4a78";
@@ -62,11 +63,12 @@ public class AzureAuthorityTest
         };
         final AzureAuthority cut = new AzureAuthority(authorityHostUrl, NullUserAgent.INSTANCE, testDeviceFlow);
 
-        final TokenPair actualTokenPair = cut.acquireToken(targetUri, TEST_CLIENT_ID, TEST_RESOURCE, callback);
+        final TokenPair actualTokenPair = cut.acquireToken(targetUri, TEST_CLIENT_ID, TEST_RESOURCE, TEST_REDIRECT_URI, callback);
 
         Assert.assertEquals(TEST_ACCESS_TOKEN, actualTokenPair.AccessToken.Value);
         Assert.assertEquals(TEST_REFRESH_TOKEN, actualTokenPair.RefreshToken.Value);
         Assert.assertEquals(TEST_RESOURCE, testDeviceFlow.getResource());
+        Assert.assertEquals(TEST_REDIRECT_URI, testDeviceFlow.getRedirectUri());
         Assert.assertEquals(1, requestAuthorizationCalls.get());
         Assert.assertEquals(1, requestTokenCalls.get());
         Assert.assertEquals(1, callbackCalls.get());
@@ -107,10 +109,11 @@ public class AzureAuthorityTest
         };
         final AzureAuthority cut = new AzureAuthority(authorityHostUrl, NullUserAgent.INSTANCE, testDeviceFlow);
 
-        final TokenPair actualTokenPair = cut.acquireToken(targetUri, TEST_CLIENT_ID, TEST_RESOURCE, callback);
+        final TokenPair actualTokenPair = cut.acquireToken(targetUri, TEST_CLIENT_ID, TEST_RESOURCE, TEST_REDIRECT_URI, callback);
 
         Assert.assertEquals(null, actualTokenPair);
         Assert.assertEquals(TEST_RESOURCE, testDeviceFlow.getResource());
+        Assert.assertEquals(TEST_REDIRECT_URI, testDeviceFlow.getRedirectUri());
         Assert.assertEquals(1, requestAuthorizationCalls.get());
         Assert.assertEquals(1, requestTokenCalls.get());
         Assert.assertEquals(1, callbackCalls.get());


### PR DESCRIPTION
Manual testing
--------------

1. Deleted the credentials associated with a _Visual Studio Team Services_ account.
2. Performed a `git fetch`.
3. The JavaFX-based web browser appeared (notice how it now says "Visual Studio Team Services"):
![aad client id](https://cloud.githubusercontent.com/assets/297515/16510632/f3a7535c-3f15-11e6-8a2b-ef70be74f58d.png)
4. I completed the sign-in with 2-factor authentication.
5. The `fetch` completed.
6. I deleted the credentials again.
7. Performed a `git fetch` again.
8. The JavaFX-based web browser again appeared.
9. This time I closed the window.  The GCM4ML fell back to _Device Login_ mode and asked me to go to https://aka.ms/devicelogin and enter a user code.
10. I opened a browser and entered the user code (notice how it now says "Visual Studio Team Services"):
![aad client id with device login](https://cloud.githubusercontent.com/assets/297515/16510682/48d31db6-3f16-11e6-9110-081d173045e9.png)
11. I completed the sign in.
12. The `fetch` completed.

Mission accomplished!
