### PR TITLE
Support NEW VSTS Identity Service Requirement

### DIFF
--- a/src/main/java/com/microsoft/alm/authentication/VsoAzureAuthority.java
+++ b/src/main/java/com/microsoft/alm/authentication/VsoAzureAuthority.java
@@ -53,10 +53,6 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
      */
     @Override public Token generatePersonalAccessToken(final URI targetUri, final Token accessToken, final VsoTokenScope tokenScope, final boolean requireCompactToken)
     {
-        final String TokenAuthHost = "app.vssps.visualstudio.com";
-        final String SessionTokenUrl = "https://" + TokenAuthHost + "/_apis/token/sessiontokens?api-version=1.0";
-        final String CompactTokenUrl = SessionTokenUrl + "&tokentype=compact";
-
         Debug.Assert(targetUri != null, "The targetUri parameter is null");
         Debug.Assert(accessToken != null && !StringHelper.isNullOrWhiteSpace(accessToken.Value) && (accessToken.Type == TokenType.Access || accessToken.Type == TokenType.Federated), "The accessToken parameter is null or invalid");
         Debug.Assert(tokenScope != null, "The tokenScope parameter is invalid");
@@ -72,7 +68,7 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
 
             if (populateTokenTargetId(targetUri, accessToken))
             {
-                final URI requestUrl = URI.create(requireCompactToken ? CompactTokenUrl : SessionTokenUrl);
+                final URI requestUrl = createPersonalAccessTokenRequestUri(client, targetUri, requireCompactToken);
 
                 final StringContent content = getAccessTokenRequestBody(targetUri, accessToken, tokenScope);
                 final HttpURLConnection response = client.post(requestUrl, content);
@@ -94,6 +90,57 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
             throw new Error(e);
         }
         return null;
+    }
+
+    private URI createPersonalAccessTokenRequestUri(final HttpClient client, final URI targetUri,
+                                                    final boolean requireCompactToken) throws IOException
+    {
+        final String SessionTokenUrl = "_apis/token/sessiontokens?api-version=1.0";
+        final String CompactTokenUrl = SessionTokenUrl + "&tokentype=compact";
+
+        Debug.Assert(client != null, "The client is null");
+
+        final URI identityServiceUri = getIdentityServiceUri(client, targetUri);
+        if (identityServiceUri == null)
+        {
+            throw new RuntimeException("Failed to find Identity Service for " + targetUri.toString());
+        }
+
+        String url = identityServiceUri.toString();
+
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+
+        url += requireCompactToken ? CompactTokenUrl : SessionTokenUrl;
+
+        return URI.create(url);
+    }
+
+    private URI getIdentityServiceUri(final HttpClient client, final URI targetUri) throws IOException
+    {
+        final String locationServiceUrlFormat = "https://%1$s/_apis/ServiceDefinitions/LocationService2/951917AC-A960-4999-8464-E3F0AA25B381?api-version=1.0";
+
+        Debug.Assert(client != null, ("The client parameter is null."));
+        Debug.Assert(targetUri != null && targetUri.isAbsolute(), "The targetUri parameter is null or invalid");
+
+        final String locationServiceUrl = String.format(locationServiceUrlFormat, targetUri.getHost());
+        URI identityServiceUri = null;
+
+        final HttpURLConnection response = client.get(URI.create(locationServiceUrl));
+        if (response.getResponseCode() == HttpURLConnection.HTTP_OK)
+        {
+            final String responseText = HttpClient.readToString(response);
+
+            // Identity Service uri is the "location" field.
+            identityServiceUri = parseLocationFromJson(responseText);
+            if (identityServiceUri != null)
+            {
+                Trace.writeLine("   parsed identity service url: " + identityServiceUri);
+            }
+        }
+
+        return identityServiceUri;
     }
 
     public boolean populateTokenTargetId(final URI targetUri, final Token accessToken)
@@ -218,6 +265,26 @@ class VsoAzureAuthority extends AzureAuthority implements IVsoAuthority
         }
 
         return result;
+    }
+
+    private static final Pattern LOCATION_PATTERN = Pattern.compile(
+            "\"location\"\\s*:\\s*\"([^\"]+)\"",
+            Pattern.CASE_INSENSITIVE
+    );
+    static URI parseLocationFromJson(final String json)
+    {
+        URI locationServiceUri = null;
+        if (!StringHelper.isNullOrWhiteSpace(json))
+        {
+            // find the 'location : <value>' portion of the result content, if any
+            final Matcher matcher = LOCATION_PATTERN.matcher(json);
+            if (matcher.find())
+            {
+                final String location = matcher.group(1);
+                locationServiceUri = URI.create(location);
+            }
+        }
+        return locationServiceUri;
     }
 
     private StringContent getAccessTokenRequestBody(final URI targetUri, final Token accessToken, final VsoTokenScope tokenScope)

--- a/src/test/groovy/com/microsoft/alm/authentication/VsoAzureAuthorityTest.groovy
+++ b/src/test/groovy/com/microsoft/alm/authentication/VsoAzureAuthorityTest.groovy
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.authentication;
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+/**
+ * A class to test {@see DeviceFlowResponse}.
+ */
+@CompileStatic
+public class VsoAzureAuthorityTest {
+
+    @Test
+    public void parseLocationServiceUriFromJson_success() throws Exception {
+        final json = """
+        {
+            "serviceType": "LocationService2",
+            "identifier": "852017ac-a960-5000-8464-e3f0aa25b381",
+            "displayName": "SPS Location Service",
+            "relativeToSetting": "fullyQualified",
+            "description": "",
+            "serviceOwner": "00000000-0000-0000-0000-000000000000",
+            "locationMappings": [{
+                "accessMappingMoniker": "HostGuidAccessMapping",
+                "location": "https://app.vssps.visualstudio.com/Ca576a7c5-ab56-424e-91ba-66c86e0fff0d/"
+            }],
+            "toolId": "Framework",
+            "parentServiceType": "LocationService2",
+            "parentIdentifier": "b6cd35eb-148e-4aad-bbb3-d31576d75958",
+            "properties": {}
+        }
+        """
+
+        final URI locationService = VsoAzureAuthority.parseLocationFromJson(json);
+        assertEquals("https://app.vssps.visualstudio.com/Ca576a7c5-ab56-424e-91ba-66c86e0fff0d/", locationService.toString());
+    }
+
+    @Test
+    public void parseLocationServiceFromAppVsspsJson_success() throws Exception {
+        final json = """
+        {
+            "locationMappings": [{
+                "accessMappingMoniker": "HostGuidAccessMapping",
+                "location": "https://app.vssps.visualstudio.com/"
+            }],
+        }
+        """
+
+        final URI locationService = VsoAzureAuthority.parseLocationFromJson(json);
+        assertEquals("https://app.vssps.visualstudio.com/", locationService.toString());
+    }
+
+    @Test
+    public void parseLocationServiceFromAppVsspsNoSlashJson_success() throws Exception {
+        final json = """
+        {
+            "locationMappings": [{
+                "accessMappingMoniker": "HostGuidAccessMapping",
+                "location": "https://app.vssps.visualstudio.com"
+            }]
+        }
+        """
+
+        final URI locationService = VsoAzureAuthority.parseLocationFromJson(json);
+        assertEquals("https://app.vssps.visualstudio.com", locationService.toString());
+    }
+}


### PR DESCRIPTION
Based on commit [70af3d ](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/pull/298/commits/70af3d7d7fa60b74c32fa765194ab8b942a46343)from Git-Credential_manager-for-Windows

Manual test:
1. Compile and install gcm4ml locally
2. Enable debug from .gitconfig
3. Remove cached credentials (on Mac, it's saved in keychain.)
4. Clone a repo hosted by VSTS and observe:
```
VsoAzureAuthority::populateTokenTargetId
VsoAzureAuthority::createConnectionDataRequest
   validating token
   target identity is add8a40a-597c-43ff-93fa-e0153bc896ab
   parsed identity service url: https://app.vssps.visualstudio.com/Aadd8a40a-597c-43ff-93fa-e0153bc896ab/
   creating access token scoped to 'vso.code_write' for 'add8a40a-597c-43ff-93fa-e0153bc896ab'
   personal access token acquisition succeeded.
SecretStore::writeCredentials
```

Verify clone is successful and credential is saved properly.