### PR TITLE
Support Java 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ addons:
       - openjdk-6-jdk
 
 # https://stackoverflow.com/questions/14694139/how-to-resolve-dependencies-between-modules-within-multi-module-project
-install: mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
+install:
+  - echo "Downloading Maven 3.0";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.0
+  - export PATH=$M2_HOME/bin:$PATH 
+  - mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
 script:
   # add our bin folder to the PATH so our fake ping will be picked up when running under Travis CI
   # Inspiration: https://github.com/nono/cozy-desktop/commit/26ab9df277d1cbf781e9e476d022988ab0113154

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,7 @@
 ---
 language: java
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 # https://stackoverflow.com/questions/14694139/how-to-resolve-dependencies-between-modules-within-multi-module-project
-install:
-  - echo "Downloading Maven 3.2.2";
-  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip || travis_terminate 1
-  - unzip -qq apache-maven-3.2.2-bin.zip || travis_terminate 1
-  - export M2_HOME=$PWD/apache-maven-3.2.2
-  - export PATH=$M2_HOME/bin:$PATH 
-  - mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
+install: mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
 script:
   # add our bin folder to the PATH so our fake ping will be picked up when running under Travis CI
   # Inspiration: https://github.com/nono/cozy-desktop/commit/26ab9df277d1cbf781e9e476d022988ab0113154
@@ -22,4 +11,4 @@ script:
 # https://docs.travis-ci.com/user/migrating-from-legacy/
 sudo: false
 jdk:
-  - openjdk6
+  - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 ---
 language: java
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 # https://stackoverflow.com/questions/14694139/how-to-resolve-dependencies-between-modules-within-multi-module-project
 install: mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ addons:
 
 # https://stackoverflow.com/questions/14694139/how-to-resolve-dependencies-between-modules-within-multi-module-project
 install:
-  - echo "Downloading Maven 3.0";
-  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
-  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
-  - export M2_HOME=$PWD/apache-maven-3.0
+  - echo "Downloading Maven 3.2.2";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.2.2-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.2.2
   - export PATH=$M2_HOME/bin:$PATH 
   - mvn compile org.apache.maven.plugins:maven-dependency-plugin:2.10:go-offline --batch-mode --show-version
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -519,9 +519,14 @@ Licensed under the MIT license. See License.txt in the project root. -->
 
   <dependencies>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.microsoft.alm</groupId>
       <artifactId>oauth2-useragent</artifactId>
-      <version>0.11.2</version>
+      <version>0.11.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.alm</groupId>


### PR DESCRIPTION
There was a change made to the oauth2-useragent dependency to fix an
issue with parsing newer versions of Java. This change updates to that
newer version to include the fix.

Additionally, it appears javax.xml.bind is no longer included with Java
9. This has been included as a maven dependency to resolve class def
errors once the oauth2-useragent error was resolved.