### PR TITLE
[maven-release-plugin] Prepare for release 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
 
   <groupId>com.microsoft.alm</groupId>
   <artifactId>git-credential-manager</artifactId>
-  <version>2.0.4-SNAPSHOT</version>
+  <version>2.0.4</version>
   <packaging>jar</packaging>
 
   <name>Git Credential Manager for Mac and Linux</name>
@@ -39,7 +39,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
     <connection>scm:git:https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux.git</connection>
     <developerConnection>scm:git:https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux.git</developerConnection>
     <url>https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux</url>
-    <tag>HEAD</tag>
+    <tag>git-credential-manager-2.0.4</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
@whoisj @yacaovsnc @leantk @madhurig @kaylangan @jrbriggs  This preps for release 2.0.4 of GCM4ML so that people have some way of getting it with Java 9/Java 10 support.