### PR TITLE
Update dependencies for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M2</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -245,7 +245,7 @@ Licensed under the MIT license. See License.txt in the project root. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
The latest Java 11 version required a few updates to dependencies in order to build successfully.