### PR TITLE
Fallback when JAVA_HOME is not set

### DIFF
--- a/templates/git-credential-manager
+++ b/templates/git-credential-manager
@@ -1,2 +1,9 @@
 #!/bin/sh
-$JAVA_HOME/bin/java -jar "/usr/lib/git-credential-manager-${version}.jar" "$@"
+
+JAVA_EXEC="$JAVA_HOME/bin/java"
+
+if [ -z "$JAVA_HOME" ]; then
+    JAVA_EXEC="java"
+fi
+
+$JAVA_EXEC -jar "/usr/lib/git-credential-manager-${version}.jar" "$@"


### PR DESCRIPTION
The shell script to run the credential manager makes the assumption that JAVA_HOME is set. This is a crude attempt at just falling back to what's in the user's PATH if there's no JAVA_HOME set.